### PR TITLE
fix: event stream reconnection

### DIFF
--- a/src/lib/hue-api/api.ts
+++ b/src/lib/hue-api/api.ts
@@ -17,11 +17,13 @@ export interface ResourceApi {
 
 class HueApi implements ResourceApi {
   private hubUrl: string;
+  private requestTimeout: number;
   public readonly lightResource: LightResource;
   private axiosInstance: AxiosInstance;
 
-  constructor(hubUrl: string) {
+  constructor(hubUrl: string, requestTimeout: number = 2000) {
     this.hubUrl = hubUrl;
+    this.requestTimeout = requestTimeout;
     this.lightResource = new LightResource(this);
     this.axiosInstance = axios.create({
       baseURL: this.hubUrl,
@@ -70,17 +72,19 @@ class HueApi implements ResourceApi {
       const { data } = await this.axiosInstance.request({
         method,
         url: endpoint,
-        data: body
+        data: body,
+        timeout: this.requestTimeout
       });
       return data;
     } catch (error: any) {
+      // FIXME return error code
       // axios error handing, taken from docs
       if (error.response) {
-        log.error("philips hue api response error", error.response.data);
+        log.error("philips hue api response error (%s %s)", method, endpoint, error.response.data);
       } else if (error.request) {
-        log.error("philips hue api request error", error.request);
+        log.error("philips hue api request error (%s %s) %s: %s", method, endpoint, error.code, error.message);
       } else {
-        log.error("philips hue api unknown error", error.message);
+        log.error("philips hue api unknown error (%s %s)", method, endpoint, error.message);
       }
     }
   }

--- a/src/lib/hue-api/event-stream.ts
+++ b/src/lib/hue-api/event-stream.ts
@@ -19,16 +19,20 @@ class HueEventStream extends EventEmitter {
     super();
   }
 
-  connect(hubUrl: string, authKey: string) {
+  connect(hubUrl: string, authKey: string, connectionTimeout: number = 6000) {
     if (this.connected) {
       return;
+    }
+    if (this.es) {
+      this.es.close();
     }
     const dispatcher = new Agent({
       connect: {
         rejectUnauthorized: false,
         checkServerIdentity: () => {
           return undefined;
-        }
+        },
+        timeout: connectionTimeout
       }
     });
     const headers = {
@@ -70,7 +74,7 @@ class HueEventStream extends EventEmitter {
     };
 
     this.es.onerror = (err) => {
-      log.debug("Philips Hue event stream error", err);
+      log.warn("Philips Hue event stream error %s: %s", err.code ? err.code : "", err.message);
       this.connected = false;
       this.emit("disconnected");
     };


### PR DESCRIPTION
# Description

Changes:
- Close the old event stream before a new connection attempt.
  This amplified the error callbacks, triggering more and more reconnections.
- Limit the event stream connection timeout to 6s.
  Do not rely on default framework timeout, which seems to be 10s.
- Improve error logging, only log relevant fields instead of the full error object.

The focus of this PR is on the event stream reconnection fix.
The connection and reconnection timeouts can be made configurable in the future. A backoff reconnection logic can also be implemented later.

Fixes #33

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Connectivity test by unplugging and replugging the ethernet cable of the Hue hub.
- Observing integration logs.

Now it's always a 2 second reconnection delay with a maximum of 6 second connection timeout, until the Hub is available again:
```
  philips-hue:debug Philips Hue event stream error : TypeError: fetch failed: connect EHOSTDOWN 192.168.16.5:443 - Local (192.168.16.148:53836) +2s
  philips-hue:warn Event stream disconnected, trying to reconnect +2s
  philips-hue:debug Philips Hue event stream error : TypeError: fetch failed: connect EHOSTDOWN 192.168.16.5:443 - Local (192.168.16.148:53857) +2s
  philips-hue:warn Event stream disconnected, trying to reconnect +2s
  philips-hue:debug Philips Hue event stream error : TypeError: fetch failed: connect EHOSTDOWN 192.168.16.5:443 - Local (192.168.16.148:53873) +2s
  philips-hue:warn Event stream disconnected, trying to reconnect +2s
  philips-hue:debug Philips Hue event stream error : TypeError: fetch failed: connect EHOSTDOWN 192.168.16.5:443 - Local (192.168.16.148:53899) +2s
  philips-hue:warn Event stream disconnected, trying to reconnect +2s
  philips-hue:debug Philips Hue event stream error : TypeError: fetch failed: connect EHOSTDOWN 192.168.16.5:443 - Local (192.168.16.148:53913) +2s
  philips-hue:warn Event stream disconnected, trying to reconnect +2s
  philips-hue:debug Philips Hue event stream error : TypeError: fetch failed: connect EHOSTDOWN 192.168.16.5:443 - Local (192.168.16.148:53933) +2s
  philips-hue:warn Event stream disconnected, trying to reconnect +2s
  philips-hue:debug Philips Hue event stream error : TypeError: fetch failed: Connect Timeout Error (attempted address: 192.168.16.5:443, timeout: 6000ms) +9s
  philips-hue:warn Event stream disconnected, trying to reconnect +9s
  philips-hue:debug Philips Hue event stream error : TypeError: fetch failed: connect EHOSTDOWN 192.168.16.5:443 - Local (192.168.16.148:54011) +2s
  philips-hue:warn Event stream disconnected, trying to reconnect +2s
  philips-hue:debug Philips Hue event stream error : TypeError: fetch failed: connect EHOSTDOWN 192.168.16.5:443 - Local (192.168.16.148:54017) +2s
  philips-hue:warn Event stream disconnected, trying to reconnect +2s
  philips-hue:debug Philips Hue event stream error : TypeError: fetch failed: connect EHOSTDOWN 192.168.16.5:443 - Local (192.168.16.148:54021) +2s
  philips-hue:warn Event stream disconnected, trying to reconnect +2s
  philips-hue:debug Philips Hue event stream connected +2s
  philips-hue:debug event stream light update {
  id: 'A',
  id_v1: '/lights/1',
  on: { on: true },
  owner: { rid: 'B', rtype: 'device' },
  service_id: 0,
  type: 'light'
} +1m
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request represents one logical piece of work. Do not combine multiple unrelated changes into a single pull request.
- [x] My changes pass the linter tests `npm run code-check`. PRs with failing linter checks will not be merged.
- [x] I have tested and performed a self-review of my code

