### PR TITLE
fix: command error propagation and improve entity state handling

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -6,9 +6,11 @@
  */
 
 import PhilipsHue from "./lib/philips-hue.js";
+import log from "./log.js";
 
 const philipsHue = new PhilipsHue();
-philipsHue.init().catch((error) => {
-  console.error("Initialization failed:", error);
+philipsHue.init().catch((error: unknown) => {
+  // log full error object, because this should not happen
+  log.error("Initialization failed:", error);
   process.exit(1);
 });

--- a/src/lib/hue-api/api.ts
+++ b/src/lib/hue-api/api.ts
@@ -7,12 +7,36 @@
 
 import axios, { AxiosInstance } from "axios";
 import https from "node:https";
+import { StatusCodes } from "@unfoldedcircle/integration-api";
 import log from "../../log.js";
 import LightResource from "./light-resource.js";
 import { AuthenticateResult, AuthenticateSuccess, HubConfig } from "./types.js";
 
+export class HueError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: StatusCodes,
+    cause?: unknown
+  ) {
+    super(message);
+    this.name = "HueError";
+    if (cause) {
+      this.cause = cause;
+    }
+  }
+}
+
 export interface ResourceApi {
-  sendRequest(method: "GET" | "POST" | "PUT", endpoint: string, body?: any): Promise<any>;
+  /**
+   * Send a request to the Philips Hue API.
+   *
+   * @param method The HTTP method (GET, POST, PUT).
+   * @param endpoint The API endpoint.
+   * @param body Optional request body.
+   * @returns The API response data.
+   * @throws {HueError} If the request fails or returns an error status.
+   */
+  sendRequest<T>(method: "GET" | "POST" | "PUT", endpoint: string, body?: unknown): Promise<T>;
 }
 
 class HueApi implements ResourceApi {
@@ -21,7 +45,7 @@ class HueApi implements ResourceApi {
   public readonly lightResource: LightResource;
   private axiosInstance: AxiosInstance;
 
-  constructor(hubUrl: string, requestTimeout: number = 2000) {
+  constructor(hubUrl: string, requestTimeout: number = 1500) {
     this.hubUrl = hubUrl;
     this.requestTimeout = requestTimeout;
     this.lightResource = new LightResource(this);
@@ -45,47 +69,98 @@ class HueApi implements ResourceApi {
     this.axiosInstance.defaults.headers.common["hue-application-key"] = authKey;
   }
 
-  async getHubConfig() {
-    const hubHttp = this.hubUrl.replace("https://", "http://");
-    const { data } = await this.axiosInstance.get<HubConfig>(`${hubHttp}/api/config`);
-    return data;
-  }
-
-  async generateAuthKey(deviceType: string): Promise<AuthenticateSuccess> {
-    // return { username: "15S7kBmqpeYkXF1d9nnKjCV03yWgL2w3UMXBEH3C", clientkey: "6B1E833A8D532972A27C256E5A3D4A98" };
-    const { data } = await this.axiosInstance.post<AuthenticateResult[]>(`${this.hubUrl}/api`, {
-      devicetype: deviceType,
-      generateclientkey: true
-    });
-    if (!data[0]?.success) {
-      throw new Error(`Failed to generate auth key: ${data[0]?.error?.description}`);
+  private handleError(error: unknown, method: string, endpoint: string): never {
+    if (axios.isAxiosError(error)) {
+      if (error.response) {
+        log.error(
+          "Philips Hue API response error (%s %s) %d: %j",
+          method,
+          endpoint,
+          error.response.status,
+          error.response.data
+        );
+        const status = error.response.status;
+        switch (status) {
+          case 400:
+            throw new HueError("Bad request", StatusCodes.BadRequest, error);
+          case 401:
+          case 403:
+            throw new HueError("Unauthorized", StatusCodes.Unauthorized, error);
+          case 404:
+            throw new HueError("Not found", StatusCodes.NotFound, error);
+          default:
+            throw new HueError(`API error: ${status}`, StatusCodes.ServerError, error);
+        }
+      } else if (error.request) {
+        log.error("Philips Hue API request error (%s %s) %s: %s", method, endpoint, error.code, error.message);
+        if (error.code === "ECONNABORTED" || error.code === "ETIMEDOUT") {
+          throw new HueError("Request timeout", StatusCodes.Timeout, error);
+        }
+        throw new HueError("Service unavailable", StatusCodes.ServiceUnavailable, error);
+      }
     }
-    return data[0].success;
+    const message = error instanceof Error ? error.message : "Unknown error";
+    log.error("Philips Hue API unknown error (%s %s) %s", method, endpoint, message);
+    throw new HueError(message, StatusCodes.ServerError, error);
   }
 
-  async sendRequest(method: "GET" | "POST" | "PUT", endpoint: string, body?: any): Promise<any> {
-    log.msgTrace("philips hue api request", { method, endpoint });
+  /**
+   * Get the Hue hub configuration.
+   *
+   * @returns The hub configuration.
+   * @throws {HueError} If the request fails.
+   */
+  async getHubConfig() {
+    // TODO verify if new Hue pro hub still allows http access
+    const hubHttp = this.hubUrl.replace("https://", "http://");
+    try {
+      const { data } = await this.axiosInstance.get<HubConfig>(`${hubHttp}/api/config`);
+      return data;
+    } catch (error) {
+      this.handleError(error, "GET", `${hubHttp}/api/config`);
+    }
+  }
+
+  /**
+   * Generate an authentication key.
+   *
+   * @param deviceType The device type identifier.
+   * @returns The authentication success details.
+   * @throws {HueError} If the request fails or key generation is unsuccessful.
+   */
+  async generateAuthKey(deviceType: string): Promise<AuthenticateSuccess> {
+    try {
+      const { data } = await this.axiosInstance.post<AuthenticateResult[]>(`${this.hubUrl}/api`, {
+        devicetype: deviceType,
+        generateclientkey: true
+      });
+      if (!data[0]?.success) {
+        throw new HueError(`Failed to generate auth key: ${data[0]?.error?.description}`, StatusCodes.BadRequest);
+      }
+      return data[0].success;
+    } catch (error) {
+      if (error instanceof HueError) {
+        throw error;
+      }
+      this.handleError(error, "POST", `${this.hubUrl}/api`);
+    }
+  }
+
+  async sendRequest<T>(method: "GET" | "POST" | "PUT", endpoint: string, body?: unknown): Promise<T> {
+    log.msgTrace("Philips Hue API request: %s %s", method, endpoint);
     if (!this.axiosInstance.defaults.headers.common["hue-application-key"]) {
-      throw new Error("auth key is required in protected resource", { cause: "auth_key_required" });
+      throw new HueError("auth key is required in protected resource", StatusCodes.Unauthorized);
     }
     try {
-      const { data } = await this.axiosInstance.request({
+      const { data } = await this.axiosInstance.request<T>({
         method,
         url: endpoint,
         data: body,
         timeout: this.requestTimeout
       });
       return data;
-    } catch (error: any) {
-      // FIXME return error code
-      // axios error handing, taken from docs
-      if (error.response) {
-        log.error("philips hue api response error (%s %s)", method, endpoint, error.response.data);
-      } else if (error.request) {
-        log.error("philips hue api request error (%s %s) %s: %s", method, endpoint, error.code, error.message);
-      } else {
-        log.error("philips hue api unknown error (%s %s)", method, endpoint, error.message);
-      }
+    } catch (error: unknown) {
+      this.handleError(error, method, endpoint);
     }
   }
 }

--- a/src/lib/hue-api/event-stream.ts
+++ b/src/lib/hue-api/event-stream.ts
@@ -53,15 +53,11 @@ class HueEventStream extends EventEmitter {
     });
 
     this.es.onopen = () => {
-      this.connected = true;
-      this.emit("connected");
-    };
-
-    this.es.onopen = () => {
       log.debug("Philips Hue event stream connected");
       this.connected = true;
       this.emit("connected");
     };
+
     this.es.onmessage = (event) => {
       try {
         const messages = JSON.parse(event.data) as HueEvent[];
@@ -81,10 +77,11 @@ class HueEventStream extends EventEmitter {
   }
 
   disconnect() {
+    log.debug("Disconnecting Philips Hue event stream");
     if (this.es) {
       this.es.close();
       this.connected = false;
-      this.emit("disconnected");
+      // do not emit "disconnected" event, otherwise a reconnection is triggered
     }
   }
 }

--- a/src/lib/hue-api/light-resource.ts
+++ b/src/lib/hue-api/light-resource.ts
@@ -16,21 +16,21 @@ class LightResource {
   }
 
   async getLights(): Promise<LightResourceResult> {
-    return this.api.sendRequest("GET", "/clip/v2/resource/light");
+    return this.api.sendRequest<LightResourceResult>("GET", "/clip/v2/resource/light");
   }
 
   async getLight(id: string): Promise<LightResourceResult> {
-    return this.api.sendRequest("GET", `/clip/v2/resource/light/${id}`);
+    return this.api.sendRequest<LightResourceResult>("GET", `/clip/v2/resource/light/${id}`);
   }
 
   async setOn(id: string, on: boolean): Promise<LightResourceResponse> {
-    return this.api.sendRequest("PUT", `/clip/v2/resource/light/${id}`, {
+    return this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
       on: { on }
     });
   }
 
   async setBrightness(id: string, brightness: number): Promise<LightResourceResponse> {
-    return this.api.sendRequest("PUT", `/clip/v2/resource/light/${id}`, {
+    return this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
       dimming: {
         brightness: Math.max(1, Math.min(100, brightness))
       }
@@ -38,7 +38,7 @@ class LightResource {
   }
 
   async setColorTemperature(id: string, mirek: number): Promise<LightResourceResponse> {
-    return this.api.sendRequest("PUT", `/clip/v2/resource/light/${id}`, {
+    return this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
       color_temperature: {
         mirek: Math.max(153, Math.min(500, mirek))
       }
@@ -46,7 +46,7 @@ class LightResource {
   }
 
   async setColor(id: string, x: number, y: number): Promise<LightResourceResponse> {
-    return this.api.sendRequest("PUT", `/clip/v2/resource/light/${id}`, {
+    return this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
       color: {
         xy: {
           x: Math.max(0, Math.min(1, x)),
@@ -58,7 +58,7 @@ class LightResource {
 
   // not sure if it's supported by UC, it is not in light attributes
   async setEffect(id: string, effect: LightEffect): Promise<LightResourceResponse> {
-    return this.api.sendRequest("PUT", `/clip/v2/resource/light/${id}`, {
+    return this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
       effects: {
         effect: effect === "no_effect" ? undefined : effect,
         status: effect === "no_effect" ? "no_effect" : "active"
@@ -66,8 +66,8 @@ class LightResource {
     });
   }
 
-  async updateLightState(id: string, params: Partial<LightResourceParams>) {
-    return this.api.sendRequest("PUT", `/clip/v2/resource/light/${id}`, params);
+  async updateLightState(id: string, params: Partial<LightResourceParams>): Promise<LightResourceResponse> {
+    return this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, params);
   }
 }
 

--- a/src/lib/hue-api/types.ts
+++ b/src/lib/hue-api/types.ts
@@ -14,7 +14,7 @@ interface DeviceResult {
   id: string;
   product_data: ProductData;
   metadata: Metadata;
-  identify: Record<string, any>;
+  identify: Record<string, unknown>;
   services: Service[];
   type: string;
   id_v1?: string;
@@ -41,7 +41,7 @@ interface Service {
 }
 
 export interface LightResourceResult {
-  errors: any[];
+  errors: { description: string }[];
   data: LightResource[];
 }
 
@@ -60,7 +60,7 @@ export interface LightResource {
   product_data: {
     function: string;
   };
-  identify: any;
+  identify: unknown;
   service_id: number;
   on: {
     on: boolean;
@@ -69,7 +69,7 @@ export interface LightResource {
     brightness: number;
     min_dim_level?: number;
   };
-  dimming_delta: any;
+  dimming_delta: unknown;
   color_temperature?: {
     mirek: number;
     mirek_valid: boolean;
@@ -78,7 +78,7 @@ export interface LightResource {
       mirek_maximum: number;
     };
   };
-  color_temperature_delta: any;
+  color_temperature_delta: unknown;
   color?: {
     xy: {
       x: number;
@@ -202,7 +202,7 @@ export interface HueEvent {
   data: {
     id: string;
     type: string;
-    [key: string]: any;
+    [key: string]: unknown;
   }[];
   creationtime: string;
 }

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -77,8 +77,8 @@ class PhilipsHueSetup {
           username: authKey.username
         });
         const { data, errors } = await this.hueApi.lightResource.getLights();
-        if (errors.length > 0) {
-          return new SetupError("Failed to get lights");
+        if (errors && errors.length > 0) {
+          return new SetupError(`Failed to get lights: ${JSON.stringify(errors[0])}`);
         }
         this.addAvailableLights(data);
         return new SetupComplete();

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,14 +8,15 @@
 import { LightFeatures } from "@unfoldedcircle/integration-api";
 import fs from "fs";
 import { LightResource } from "./lib/hue-api/types.js";
+import log from "./log.js";
 
 export function convertImageToBase64(file: string) {
   let data;
 
   try {
     data = fs.readFileSync(file, "base64");
-  } catch (e) {
-    console.error(e);
+  } catch (e: unknown) {
+    log.error("Failed to read image file %s: %s", file, e instanceof Error ? e.message : e);
   }
   return data;
 }


### PR DESCRIPTION
# Description

- Return corresponding StatusCodes enum values for failed requests.
- Update lights after event stream connects.
- Set entity states to UNAVAILABLE if event stream disconnects.
- Don't reconnect event stream if manually disconnected.
- Improved TS: prefer unknown over any.
- Improved logging: always use logger class, flatten json data, only log relevant exception data

Fixes #35

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual tests with disconnecting the Hue bridge ethernet cable, while sending commands.
Verify reconnection of the event stream and entity state updates.
