### PR TITLE
feat: add manual Hue hub setup option

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,8 +4,13 @@
     "es6": true,
     "node": true
   },
-  "plugins": ["prettier"],
-  "extends": ["prettier"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint", "prettier"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
   "rules": {
     "prettier/prettier": [
       "error",
@@ -17,6 +22,12 @@
         "endOfLine": "auto"
       }
     ],
-    "no-unused-vars": ["warn", { "args": "none" }]
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "args": "none"
+      }
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ configured.json
 
 # JetBrains
 http-client.private.env.json
+
+/philips_hue_config.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,5 @@
 .idea/
 docs/
 node_modules/
-*.json
 CODE_OF_CONDUCT.md
+philips_hue_config.json

--- a/docs/hue-api.http
+++ b/docs/hue-api.http
@@ -1,6 +1,13 @@
 ### get hub config
 GET {{hue_bridge_url}}/api/config HTTP/1.1
 
+### check authentication
+GET {{hue_bridge_url}}/auth/v1 HTTP/1.1
+hue-application-key: {{hue_api_key}}
+
+### get account
+GET {{hue_bridge_url}}/api/{{hue_api_key}}/config HTTP/1.1
+
 ### generate api key
 ### press link button on Hub, then send request
 POST {{hue_bridge_url}}/api HTTP/1.1
@@ -23,8 +30,31 @@ Content-Type: application/json
     }
 %}
 
+### get resources
+GET {{hue_bridge_url}}/clip/v2/resource HTTP/1.1
+hue-application-key: {{hue_api_key}}
 
-### get hub lights
+### get scenes
+### Scenes are used to store and recall settings for a group of lights.
+GET {{hue_bridge_url}}/clip/v2/resource/scene HTTP/1.1
+hue-application-key: {{hue_api_key}}
+
+### get rooms
+### Rooms group devices and each device can only be part of one room.
+GET {{hue_bridge_url}}/clip/v2/resource/room HTTP/1.1
+hue-application-key: {{hue_api_key}}
+
+### get zones
+### Zones group services and each service can be part of multiple zones.
+GET {{hue_bridge_url}}/clip/v2/resource/zone HTTP/1.1
+hue-application-key: {{hue_api_key}}
+
+### get grouped lights
+GET {{hue_bridge_url}}/clip/v2/resource/grouped_light HTTP/1.1
+hue-application-key: {{hue_api_key}}
+
+### get light services
+### These are offered by devices with lighting capabilities.
 GET {{hue_bridge_url}}/clip/v2/resource/light HTTP/1.1
 hue-application-key: {{hue_api_key}}
 
@@ -67,3 +97,11 @@ hue-application-key: {{hue_api_key}}
     "on": false
   }
 }
+
+### get temperature services
+GET {{hue_bridge_url}}/clip/v2/resource/temperature HTTP/1.1
+hue-application-key: {{hue_api_key}}
+
+### get light level services
+GET {{hue_bridge_url}}/clip/v2/resource/light_level HTTP/1.1
+hue-application-key: {{hue_api_key}}

--- a/docs/hue-api.md
+++ b/docs/hue-api.md
@@ -1,0 +1,6 @@
+# Hue API
+
+- https://developers.meethue.com/new-hue-api/
+- https://developers.meethue.com/develop/hue-api-v2/
+  - https://developers.meethue.com/develop/hue-api-v2/migration-guide-to-the-new-hue-api/
+  - https://developers.meethue.com/develop/hue-api-v2/api-reference/

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,0 +1,35 @@
+{
+  "setup": {
+    "configuration": {
+      "title": "Konfigurations-Modus",
+      "add": "Neues Gerät hinzufügen",
+      "info": "Hue Hub Informationen",
+      "remove": "Selektiertes Gerät löschen",
+      "reset": "Konfiguration zurücksetzen und neu konfigurieren",
+      "configured_devices": "Konfigurierte Geräte",
+      "action": "Aktion"
+    },
+    "discovery": {
+      "title": "Setup Modus",
+      "info": "Suche oder Verbinde auf Philips Hue Hub",
+      "description": "Leer lassen, um automatische Erkennung zu verwenden und auf _Weiter_ klicken. Der Hue Hub muss sich im gleichen Netzwerk wie die Fernbedienung befinden.",
+      "address": "IP-Adresse (manuelle Konfiguration)",
+      "discovered_title": "Wähle deinen Philips Hue Hub aus",
+      "discovered_hubs": "Gefundene Hubs"
+    },
+    "discovery_failed": {
+      "title": "Keine neuen Philips Hue Hubs gefunden",
+      "header": "Vergewissere dich, dass der Philips Hue Hub eingeschaltet und über das gleiche Netzwerk wie die Fernbedienung erreichbar ist. Bereits konfigurierte Geräte werden von der Erkennung ausgeschlossen.\nKlicke auf Weiter, um es erneut zu versuchen, oder schließe diesen Dialog, um abzubrechen."
+    },
+    "confirmation": {
+      "title": "Philips Hue Setup",
+      "header": "Benutzeraktion erforderlich",
+      "footer": "Bitte drücke die Taste auf der Philips Hue Bridge und klicke danach auf _Weiter_."
+    },
+    "info": {
+      "title": "Hub Information",
+      "not_configured": "Kein Hub konfiguriert.",
+      "lights": "Verfügbare Lichter"
+    }
+  }
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,35 @@
+{
+  "setup": {
+    "configuration": {
+      "title": "Configuration mode",
+      "add": "Add a new device",
+      "info": "Show Hue hub information",
+      "remove": "Delete selected Hue hub",
+      "reset": "Reset configuration and reconfigure",
+      "configured_devices": "Configured Hue hubs",
+      "action": "Action"
+    },
+    "discovery": {
+      "title": "Setup mode",
+      "info": "Discover or connect to Philips Hue hub",
+      "description": "Leave blank to use auto-discovery and click _Next_. The device must be on the same network as the remote.",
+      "address": "IP address (manual configuration)",
+      "discovered_title": "Select your Philips Hue hub",
+      "discovered_hubs": "Discovered hubs"
+    },
+    "discovery_failed": {
+      "title": "No new Philips Hue hubs found",
+      "header": "Please make sure that your Philips Hue hub is powered on and accessible from the same network as the remote. Already configured devices are excluded from the discovery.\nClick Next to try again, or close this dialog to abort."
+    },
+    "confirmation": {
+      "title": "Philips Hue setup",
+      "header": "User action needed",
+      "footer": "Please press the button on the Philips Hue Bridge and click _Next_."
+    },
+    "info": {
+      "title": "Hub information",
+      "not_configured": "No hub configured.",
+      "lights": "Available lights"
+    }
+  }
+}

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,35 @@
+{
+  "setup": {
+    "configuration": {
+      "title": "Mode configuration",
+      "add": "Ajouter un nouvel appareil",
+      "info": "Afficher les informations du hub Hue",
+      "remove": "Supprimer l'appareil sélectionné",
+      "reset": "Réinitialiser la configuration et reconfigurer",
+      "configured_devices": "Appareils configurés",
+      "action": "Action"
+    },
+    "discovery": {
+      "title": "Setup mode",
+      "info": "Découvrir ou connexion à Philips Hue hub",
+      "description": "Laissez le champ vide pour utiliser la découverte automatique et cliquez sur _Suivant_. L'appareil doit être sur le même réseau que la télécommande",
+      "address": "Adresse IP (configuration manuel)",
+      "discovered_title": "setup.discovery.discovered_title",
+      "discovered_hubs": "setup.discovery.discovered_hubs"
+    },
+    "discovery_failed": {
+      "title": "Aucun nouveaux Philips Hue hub",
+      "header": "Veuillez vous assurer que votre Philips Hue hub est sous tension et accessibles depuis le même réseau que la télécommande. Les appareils déjà configurés sont exclus de la découverte.\nCliquez sur Suivant pour réessayer, ou fermez cette boîte de dialogue pour abandonner."
+    },
+    "confirmation": {
+      "title": "Configuration de Philips Hue",
+      "header": "Action de l'utilisateur requise",
+      "footer": "Veuillez appuyer sur le bouton du pont Philips Hue et cliquer sur _Suivant_."
+    },
+    "info": {
+      "title": "Informations sur le hub",
+      "not_configured": "Aucun hub configuré.",
+      "lights": "Lumières disponibles"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,16 @@
         "axios": "^1.13.2",
         "bonjour-service": "^1.3.0",
         "eventsource": "^3.0.7",
-        "node-hue-api": "^5.0.0-beta.16",
+        "i18n": "^0.15.3",
         "undici": "^7.18.2"
       },
       "devDependencies": {
         "@types/debug": "^4.1.12",
+        "@types/i18n": "^0.13.12",
         "@types/node": "^22.10.2",
         "@types/qs": "^6.9.17",
+        "@typescript-eslint/eslint-plugin": "^8.53.1",
+        "@typescript-eslint/parser": "^8.53.1",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
@@ -134,6 +137,50 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
     },
+    "node_modules/@messageformat/core": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@messageformat/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-NgCFubFFIdMWJGN5WuQhHCNmzk7QgiVfrViFxcS99j7F5dDS5EP6raR54I+2ydhe4+5/XTn/YIEppFaqqVWHsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@messageformat/date-skeleton": "^1.0.0",
+        "@messageformat/number-skeleton": "^1.0.0",
+        "@messageformat/parser": "^5.1.0",
+        "@messageformat/runtime": "^3.0.1",
+        "make-plural": "^7.0.0",
+        "safe-identifier": "^0.4.1"
+      }
+    },
+    "node_modules/@messageformat/date-skeleton": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@messageformat/date-skeleton/-/date-skeleton-1.1.0.tgz",
+      "integrity": "sha512-rmGAfB1tIPER+gh3p/RgA+PVeRE/gxuQ2w4snFWPF5xtb5mbWR7Cbw7wCOftcUypbD6HVoxrVdyyghPm3WzP5A==",
+      "license": "MIT"
+    },
+    "node_modules/@messageformat/number-skeleton": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@messageformat/number-skeleton/-/number-skeleton-1.2.0.tgz",
+      "integrity": "sha512-xsgwcL7J7WhlHJ3RNbaVgssaIwcEyFkBqxHdcdaiJzwTZAWEOD8BuUFxnxV9k5S0qHN3v/KzUpq0IUpjH1seRg==",
+      "license": "MIT"
+    },
+    "node_modules/@messageformat/parser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@messageformat/parser/-/parser-5.1.1.tgz",
+      "integrity": "sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==",
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1"
+      }
+    },
+    "node_modules/@messageformat/runtime": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@messageformat/runtime/-/runtime-3.0.2.tgz",
+      "integrity": "sha512-dkIPDCjXcfhSHgNE1/qV6TeczQZR59Yx0xXeafVKgK3QVWoxc38ljwpksUpnzCGvN151KUbCJTDZVmahtf1YZw==",
+      "license": "MIT",
+      "dependencies": {
+        "make-plural": "^7.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -172,15 +219,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@peter-murray/hue-bridge-model": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@peter-murray/hue-bridge-model/-/hue-bridge-model-2.1.1.tgz",
-      "integrity": "sha512-RdnTRY6YOP0TS1z7elRuvD2LsxV+/fwZsl967Ihwvk/SUjQ0247plc6YRM2bEeDBUi06HpcE+tGV4GQBMlVAeg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -203,6 +241,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/i18n": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/@types/i18n/-/i18n-0.13.12.tgz",
+      "integrity": "sha512-iAd2QjKh+0ToBXocmCS3m38GskiaGzmSV1MTQz2GaOraqSqBiLf46J7u3EGINl+st+Uk4lO3OL7QyIjTJlrWIg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -227,6 +272,275 @@
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.53.1.tgz",
+      "integrity": "sha512-cFYYFZ+oQFi6hUnBTbLRXfTJiaQtYE3t4O692agbBl+2Zy+eqSKWtPjhPXJu1G7j4RLjKgeJPDdq3EqOwmX5Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.53.1",
+        "@typescript-eslint/type-utils": "8.53.1",
+        "@typescript-eslint/utils": "8.53.1",
+        "@typescript-eslint/visitor-keys": "8.53.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.53.1",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.1.tgz",
+      "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.53.1",
+        "@typescript-eslint/types": "8.53.1",
+        "@typescript-eslint/typescript-estree": "8.53.1",
+        "@typescript-eslint/visitor-keys": "8.53.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.1.tgz",
+      "integrity": "sha512-WYC4FB5Ra0xidsmlPb+1SsnaSKPmS3gsjIARwbEkHkoWloQmuzcfypljaJcR78uyLA1h8sHdWWPHSLDI+MtNog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.53.1",
+        "@typescript-eslint/types": "^8.53.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.1.tgz",
+      "integrity": "sha512-Lu23yw1uJMFY8cUeq7JlrizAgeQvWugNQzJp8C3x8Eo5Jw5Q2ykMdiiTB9vBVOOUBysMzmRRmUfwFrZuI2C4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.53.1",
+        "@typescript-eslint/visitor-keys": "8.53.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.1.tgz",
+      "integrity": "sha512-qfvLXS6F6b1y43pnf0pPbXJ+YoXIC7HKg0UGZ27uMIemKMKA6XH2DTxsEDdpdN29D+vHV07x/pnlPNVLhdhWiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.53.1.tgz",
+      "integrity": "sha512-MOrdtNvyhy0rHyv0ENzub1d4wQYKb2NmIqG7qEqPWFW7Mpy2jzFC3pQ2yKDvirZB7jypm5uGjF2Qqs6OIqu47w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.53.1",
+        "@typescript-eslint/typescript-estree": "8.53.1",
+        "@typescript-eslint/utils": "8.53.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.1.tgz",
+      "integrity": "sha512-jr/swrr2aRmUAUjW5/zQHbMaui//vQlsZcJKijZf3M26bnmLj8LyZUpj8/Rd6uzaek06OWsqdofN/Thenm5O8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.1.tgz",
+      "integrity": "sha512-RGlVipGhQAG4GxV1s34O91cxQ/vWiHJTDHbXRr0li2q/BGg3RR/7NM8QDWgkEgrwQYCvmJV9ichIwyoKCQ+DTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.53.1",
+        "@typescript-eslint/tsconfig-utils": "8.53.1",
+        "@typescript-eslint/types": "8.53.1",
+        "@typescript-eslint/visitor-keys": "8.53.1",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.1.tgz",
+      "integrity": "sha512-c4bMvGVWW4hv6JmDUEG7fSYlWOl3II2I4ylt0NM+seinYQlZMQIaKaXIIVJWt9Ofh6whrpM+EdDQXKXjNovvrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.53.1",
+        "@typescript-eslint/types": "8.53.1",
+        "@typescript-eslint/typescript-estree": "8.53.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.1.tgz",
+      "integrity": "sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.53.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@unfoldedcircle/integration-api": {
       "version": "0.3.0",
@@ -355,12 +669,6 @@
         "fast-deep-equal": "^3.1.3",
         "multicast-dns": "^7.2.5"
       }
-    },
-    "node_modules/bottleneck": {
-      "version": "2.19.5",
-      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
-      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
-      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -843,6 +1151,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-printf": {
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.6.10.tgz",
+      "integrity": "sha512-GwTgG9O4FVIdShhbVF3JxOgSBY2+ePGsu2V/UONgoCPzF9VY6ZdBMKsHKCYQHZwNk3qNouUolRDsgVxcVA5G1w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -851,6 +1168,24 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-entry-cache": {
@@ -1113,6 +1448,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/i18n": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.15.3.tgz",
+      "integrity": "sha512-tW/AA5R4lJZLnd60Agcd0PfXB1C2G7UqTrdNewuv/SIYdxcHkCE8w4Zx1SgCjJ+2BLuAAGIG/KXb/xNYF1lO5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@messageformat/core": "^3.4.0",
+        "debug": "^4.4.3",
+        "fast-printf": "^1.6.10",
+        "make-plural": "^7.4.0",
+        "math-interval-parser": "^2.0.1",
+        "mustache": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mashpie"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -1290,6 +1645,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/make-plural": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.5.0.tgz",
+      "integrity": "sha512-0booA+aVYyVFoR67JBHdfVk0U08HmrBH2FrtmBqBa+NldlqXv/G2Z9VQuQq6Wgp2jDWdybEWGfBkk1cq5264WA==",
+      "license": "Unicode-DFS-2016"
+    },
+    "node_modules/math-interval-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
+      "integrity": "sha512-VmlAmb0UJwlvMyx8iPhXUDnVW1F9IrGEd9CIOmv+XL8AErCUUuozoDMrgImvnYt2A+53qVX/tPW6YJurMKYsvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1333,6 +1703,12 @@
         "node": "*"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1352,53 +1728,21 @@
         "multicast-dns": "cli.js"
       }
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-dns-sd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/node-dns-sd/-/node-dns-sd-1.0.1.tgz",
-      "integrity": "sha512-GCL6FgvkHoDnvJ1Yamf8mY16lYymWmYxjne4q1MC9C8sTZn9XR3BbwsrBQGikMESMFDFLC5MovNZn6wFl1yrdQ==",
-      "license": "MIT"
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-hue-api": {
-      "version": "5.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/node-hue-api/-/node-hue-api-5.0.0-beta.16.tgz",
-      "integrity": "sha512-JsCQlhOt9e556zzb50BzsMjQ2/Pj1J6srtQS+6mwAhjXsCMT8jm6wEmQCDb7sXVn+5LFtKpq4nmYix1fBWtm8A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@peter-murray/hue-bridge-model": "^2.0.1",
-        "bottleneck": "^2.19.5",
-        "node-dns-sd": "^1.0.1",
-        "node-fetch": "^2.6.1"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -1501,6 +1845,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/prelude-ls": {
@@ -1641,6 +1998,25 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-identifier": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
+      "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
+      "license": "ISC"
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -1732,11 +2108,35 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -1802,22 +2202,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "format": "prettier --write .",
-    "code-check": "prettier --check . && eslint .",
-    "lint": "eslint --fix",
+    "code-check": "prettier --check . && eslint . --ext .ts",
+    "lint": "eslint --fix --ext .ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
     "start": "npm run build && node dist/driver.js"
@@ -19,17 +19,20 @@
     "axios": "^1.13.2",
     "bonjour-service": "^1.3.0",
     "eventsource": "^3.0.7",
-    "node-hue-api": "^5.0.0-beta.16",
+    "i18n": "^0.15.3",
     "undici": "^7.18.2"
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",
+    "@types/i18n": "^0.13.12",
     "@types/node": "^22.10.2",
     "@types/qs": "^6.9.17",
-    "typescript": "^5.7.2",
+    "@typescript-eslint/eslint-plugin": "^8.53.1",
+    "@typescript-eslint/parser": "^8.53.1",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "typescript": "^5.7.2"
   }
 }

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -7,6 +7,18 @@
 
 import PhilipsHue from "./lib/philips-hue.js";
 import log from "./log.js";
+import i18n from "i18n";
+import path from "path";
+
+// Node.js 20.11 / 21.2
+const __dirname = import.meta.dirname;
+
+i18n.configure({
+  locales: ["en", "de", "fr"],
+  defaultLocale: "en",
+  directory: path.join(__dirname, "..", "locales"),
+  objectNotation: true
+});
 
 const philipsHue = new PhilipsHue();
 philipsHue.init().catch((error: unknown) => {

--- a/src/lib/hue-api/light-resource.ts
+++ b/src/lib/hue-api/light-resource.ts
@@ -5,8 +5,15 @@
  * @license Mozilla Public License Version 2.0, see LICENSE for more details.
  */
 
-import { ResourceApi } from "./api.js";
-import { LightEffect, LightResourceParams, LightResourceResponse, LightResourceResult } from "./types.js";
+import { HueError, ResourceApi } from "./api.js";
+import { StatusCodes } from "@unfoldedcircle/integration-api";
+import {
+  LightEffect,
+  LightResource as LightResourceData,
+  LightResourceParams,
+  LightResourceResponse,
+  LightResourceResult
+} from "./types.js";
 
 class LightResource {
   private readonly api: ResourceApi;
@@ -15,38 +22,46 @@ class LightResource {
     this.api = api;
   }
 
-  async getLights(): Promise<LightResourceResult> {
-    return this.api.sendRequest<LightResourceResult>("GET", "/clip/v2/resource/light");
+  async getLights(): Promise<LightResourceData[]> {
+    const res = await this.api.sendRequest<LightResourceResult>("GET", "/clip/v2/resource/light");
+    return res.data;
   }
 
-  async getLight(id: string): Promise<LightResourceResult> {
-    return this.api.sendRequest<LightResourceResult>("GET", `/clip/v2/resource/light/${id}`);
+  async getLight(id: string): Promise<LightResourceData> {
+    const res = await this.api.sendRequest<LightResourceResult>("GET", `/clip/v2/resource/light/${id}`);
+    if (!res.data || res.data.length === 0) {
+      throw new HueError("Light not found", StatusCodes.NotFound);
+    }
+    return res.data[0];
   }
 
-  async setOn(id: string, on: boolean): Promise<LightResourceResponse> {
-    return this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
+  async setOn(id: string, on: boolean): Promise<LightResourceResponse["data"]> {
+    const res = await this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
       on: { on }
     });
+    return res.data;
   }
 
-  async setBrightness(id: string, brightness: number): Promise<LightResourceResponse> {
-    return this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
+  async setBrightness(id: string, brightness: number): Promise<LightResourceResponse["data"]> {
+    const res = await this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
       dimming: {
         brightness: Math.max(1, Math.min(100, brightness))
       }
     });
+    return res.data;
   }
 
-  async setColorTemperature(id: string, mirek: number): Promise<LightResourceResponse> {
-    return this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
+  async setColorTemperature(id: string, mirek: number): Promise<LightResourceResponse["data"]> {
+    const res = await this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
       color_temperature: {
         mirek: Math.max(153, Math.min(500, mirek))
       }
     });
+    return res.data;
   }
 
-  async setColor(id: string, x: number, y: number): Promise<LightResourceResponse> {
-    return this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
+  async setColor(id: string, x: number, y: number): Promise<LightResourceResponse["data"]> {
+    const res = await this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
       color: {
         xy: {
           x: Math.max(0, Math.min(1, x)),
@@ -54,20 +69,23 @@ class LightResource {
         }
       }
     });
+    return res.data;
   }
 
   // not sure if it's supported by UC, it is not in light attributes
-  async setEffect(id: string, effect: LightEffect): Promise<LightResourceResponse> {
-    return this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
+  async setEffect(id: string, effect: LightEffect): Promise<LightResourceResponse["data"]> {
+    const res = await this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, {
       effects: {
         effect: effect === "no_effect" ? undefined : effect,
         status: effect === "no_effect" ? "no_effect" : "active"
       }
     });
+    return res.data;
   }
 
-  async updateLightState(id: string, params: Partial<LightResourceParams>): Promise<LightResourceResponse> {
-    return this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, params);
+  async updateLightState(id: string, params: Partial<LightResourceParams>): Promise<LightResourceResponse["data"]> {
+    const res = await this.api.sendRequest<LightResourceResponse>("PUT", `/clip/v2/resource/light/${id}`, params);
+    return res.data;
   }
 }
 

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -19,10 +19,23 @@ import {
 import { Bonjour } from "bonjour-service";
 import Config from "../config.js";
 import log from "../log.js";
-import { convertImageToBase64, delay, getHubUrl, getLightFeatures } from "../util.js";
+import { convertImageToBase64, delay, getHubUrl, getLightFeatures, i18all } from "../util.js";
 import HueApi from "./hue-api/api.js";
 import { LightResource } from "./hue-api/types.js";
 import os from "os";
+import * as uc from "@unfoldedcircle/integration-api";
+
+/**
+ * Enumeration of setup steps to keep track of user data responses.
+ */
+enum SetupSteps {
+  INIT = 0,
+  CONFIGURATION_MODE,
+  DISCOVER,
+  DEVICE_CHOICE,
+  PRESS_THE_BUTTON,
+  COMPLETED
+}
 
 interface HueHub {
   id: string;
@@ -31,6 +44,9 @@ interface HueHub {
 }
 
 class PhilipsHueSetup {
+  private setupStep = SetupSteps.INIT;
+  private cfgAddDevice = false;
+  private manualAddress = false;
   private bonjour: Bonjour;
   private hubs: HueHub[] = [];
   private hueApi: HueApi;
@@ -43,27 +59,214 @@ class PhilipsHueSetup {
     this.config = config;
   }
 
+  /**
+   * Dispatch driver setup requests to corresponding handlers.
+   *
+   * Either start the setup process or handle the provided user input data.
+   * @param msg the setup driver request object, either DriverSetupRequest,
+   *            UserDataResponse or UserConfirmationResponse
+   * @return the setup action on how to continue
+   */
   async handleSetup(msg: SetupDriver): Promise<SetupAction> {
+    if (this.setupStep === SetupSteps.COMPLETED) {
+      this.setupStep = SetupSteps.INIT;
+      return new SetupComplete();
+    }
+
     if (msg instanceof DriverSetupRequest) {
-      return await this.handleSetupRequest(msg);
+      this.setupStep = SetupSteps.INIT;
+      this.cfgAddDevice = false;
+      return await this.handleDriverSetup(msg);
+    } else if (msg instanceof UserConfirmationResponse) {
+      if (this.setupStep === SetupSteps.DISCOVER) {
+        log.debug("Received user confirmation for starting discovery again");
+        return await this.handleHubDiscovery(msg);
+      } else if (this.setupStep === SetupSteps.PRESS_THE_BUTTON) {
+        return await this.handleUserConfirmationResponse(msg);
+      }
+      log.error("No or invalid user confirmation response was received in step %d: %s", this.setupStep, msg);
+    } else if (msg instanceof UserDataResponse) {
+      if (this.setupStep === SetupSteps.CONFIGURATION_MODE && "action" in msg.inputValues) {
+        return await this.handleConfigurationMode(msg);
+      }
+      if (this.setupStep === SetupSteps.DISCOVER) {
+        return await this.handleHubDiscovery(msg);
+      }
+      if (this.setupStep === SetupSteps.DEVICE_CHOICE) {
+        return await this.handleUserDataResponse(msg);
+      }
+      log.error("No or invalid user response was received in step %d: %s", this.setupStep, msg);
+    } else if (msg instanceof uc.AbortDriverSetup) {
+      log.info("Setup was aborted with code: %s", msg.error);
+      this.hubs = [];
+      this.setupStep = SetupSteps.INIT;
     }
-    if (msg instanceof UserConfirmationResponse) {
-      return await this.handleUserConfirmationResponse(msg);
-    }
-    if (msg instanceof UserDataResponse) {
-      return await this.handleUserDataResponse(msg);
-    }
+
     return new SetupComplete();
   }
 
-  private async handleSetupRequest(msg: DriverSetupRequest): Promise<SetupAction> {
+  /**
+   * Start driver setup.
+   *
+   * Initiated by the UC Remote to set up the driver.
+   * @param msg value(s) of input fields in the first setup screen.
+   * @return the setup action on how to continue
+   */
+  private async handleDriverSetup(msg: DriverSetupRequest): Promise<SetupAction> {
+    log.debug("Setting up driver. Setup data:", msg);
+
     if (msg.reconfigure) {
-      // TODO redesign setup flow: do we really want to delete the configration at this point?
-      //      This should be done as late as possible: the user should not loose the old cfg if setup fails!
-      this.selectedHub = null;
-      this.hubs = [];
+      this.setupStep = SetupSteps.CONFIGURATION_MODE;
+
+      // get all configured devices for the user to choose from. Only a single hub is supported at the moment.
+      const dropdownDevices: { id: string; label: { en: string } }[] = [];
+      const hubCfg = this.config.getHubConfig();
+      if (hubCfg && hubCfg.ip && hubCfg.username && hubCfg.bridgeId) {
+        dropdownDevices.push({ id: hubCfg.bridgeId, label: { en: `${hubCfg.name} (${hubCfg.ip})` } });
+      }
+
+      // build user actions, based on available devices
+      const dropdownActions = [];
+
+      if (dropdownDevices.length == 0) {
+        // only a single hub is supported at the moment
+        dropdownActions.push({
+          id: "add",
+          label: i18all("setup.configuration.add")
+        });
+        // dummy entry if no devices are available
+        dropdownDevices.push({ id: "", label: { en: "---" } });
+      } else {
+        // add info, remove & reset actions if there's at least one configured device
+        dropdownActions.push({
+          id: "info",
+          label: i18all("setup.configuration.info")
+        });
+        dropdownActions.push({
+          id: "remove",
+          label: i18all("setup.configuration.remove")
+        });
+        dropdownActions.push({
+          id: "reset",
+          label: i18all("setup.configuration.reset")
+        });
+      }
+
+      return new uc.RequestUserInput(i18all("setup.configuration.title"), [
+        {
+          field: { dropdown: { value: dropdownDevices[0].id, items: dropdownDevices } },
+          id: "choice",
+          label: i18all("setup.configuration.configured_devices")
+        },
+        {
+          field: { dropdown: { value: dropdownActions[0].id, items: dropdownActions } },
+          id: "action",
+          label: i18all("setup.configuration.action")
+        }
+      ]);
+    } else {
+      // Initial setup, make sure we have a clean configuration
+      this.config.clear();
     }
-    return await this.handleHubDiscovery();
+
+    this.setupStep = SetupSteps.DISCOVER;
+    return await this.handleHubDiscovery(msg);
+  }
+
+  /**
+   * Process user data response from the configuration mode screen.
+   *
+   * User input data:
+   * - `choice` contains identifier of selected device
+   * - `action` contains the selected action identifier
+   *
+   * @param msg user input data from the configuration mode screen.
+   * @return the setup action on how to continue
+   */
+  private async handleConfigurationMode(msg: uc.UserDataResponse): Promise<uc.SetupAction> {
+    const action = msg.inputValues.action;
+
+    // workaround for web-configurator not picking up first response
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    switch (action) {
+      case "add":
+        this.cfgAddDevice = true;
+        break;
+      case "info": {
+        let hubInfos;
+        let lightInfos;
+        const hubCfg = this.config.getHubConfig();
+        if (hubCfg && hubCfg.ip && hubCfg.username) {
+          try {
+            this.hueApi.setBaseUrl(getHubUrl(hubCfg.ip));
+            const hubConfig = await this.hueApi.getHubConfig();
+
+            /// text field has Markdown support
+            hubInfos = { en: "```\n" + JSON.stringify(hubConfig, null, "  ") + "\n```" };
+          } catch (e) {
+            hubInfos = { en: `Error: ${e instanceof Error ? e.message : e}` };
+          }
+
+          // perform a connection test with API key
+          try {
+            this.hueApi.setAuthKey(hubCfg.username);
+            const data = await this.hueApi.lightResource.getLights();
+            lightInfos = { en: "```\n" + JSON.stringify(data, null, "  ") + "\n```" };
+          } catch (e) {
+            lightInfos = { en: `**Error: ${e instanceof Error ? e.message : e}**` };
+          }
+          this.hueApi.setAuthKey("");
+        } else {
+          hubInfos = i18all("setup.info.not_configured");
+          lightInfos = i18all("setup.info.not_configured");
+        }
+
+        this.setupStep = SetupSteps.COMPLETED;
+        return new uc.RequestUserInput("Philips Hue", [
+          {
+            id: "info",
+            label: i18all("setup.info.title"),
+            field: { label: { value: hubInfos } }
+          },
+          {
+            id: "lights",
+            label: i18all("setup.info.lights"),
+            field: { label: { value: lightInfos } }
+          }
+        ]);
+      }
+      case "remove": {
+        // only one hub supported at the moment
+        this.config.removeHub();
+        return new uc.SetupComplete();
+      }
+      case "reset":
+        this.config.clear();
+        break;
+      default:
+        log.error("Invalid configuration action: %s", action);
+        return new uc.SetupError(uc.IntegrationSetupError.Other);
+    }
+
+    this.setupStep = SetupSteps.DISCOVER;
+
+    return new uc.RequestUserInput(i18all("setup.discovery.title"), [
+      {
+        id: "info",
+        label: i18all("setup.discovery.info"),
+        field: {
+          label: {
+            value: i18all("setup.discovery.description")
+          }
+        }
+      },
+      {
+        field: { text: { value: "" } },
+        id: "address",
+        label: i18all("setup.discovery.address")
+      }
+    ]);
   }
 
   private async handleUserConfirmationResponse(msg: UserConfirmationResponse): Promise<SetupAction> {
@@ -73,24 +276,25 @@ class PhilipsHueSetup {
         const authKey = await this.hueApi.generateAuthKey("unfoldedcircle#" + os.hostname());
         this.hueApi.setAuthKey(authKey.username);
         this.config.updateHubConfig({
+          name: this.selectedHub.name,
           ip: this.selectedHub.ip,
-          username: authKey.username
+          username: authKey.username,
+          bridgeId: this.selectedHub.id
         });
-        const { data, errors } = await this.hueApi.lightResource.getLights();
-        if (errors && errors.length > 0) {
-          return new SetupError(`Failed to get lights: ${JSON.stringify(errors[0])}`);
-        }
+        const data = await this.hueApi.lightResource.getLights();
         this.addAvailableLights(data);
         return new SetupComplete();
       } catch (error) {
         log.error("Failed to get hub config", error);
-        return new SetupError("Failed to get hub config");
+        return new SetupError("Failed to get hub configuration");
       }
     }
     return new SetupError("User did not confirm");
   }
 
   private async handleUserDataResponse(msg: UserDataResponse): Promise<SetupAction> {
+    log.debug("Received user input for driver setup.", JSON.stringify(msg));
+
     if (!msg.inputValues.hubId) {
       return new SetupError("No hub selected");
     }
@@ -104,11 +308,13 @@ class PhilipsHueSetup {
       log.error("Failed to convert image to base64");
       return new SetupError("Failed to process image during setup");
     }
+
+    this.setupStep = SetupSteps.PRESS_THE_BUTTON;
     return new RequestUserConfirmation(
-      "Philips Hue setup",
-      "User action needed",
+      i18all("setup.confirmation.title"),
+      i18all("setup.confirmation.header"),
       img,
-      "Please press the button on the Philips Hue Bridge and click next."
+      i18all("setup.confirmation.footer")
     );
   }
 
@@ -119,50 +325,107 @@ class PhilipsHueSetup {
     });
   }
 
-  private async handleHubDiscovery(): Promise<SetupAction> {
+  private async handleHubDiscovery(
+    msg: uc.DriverSetupRequest | uc.UserConfirmationResponse | uc.UserDataResponse
+  ): Promise<SetupAction> {
+    this.manualAddress = false;
     this.hubs = [];
-    this.bonjour.find({ type: "hue" }, (service) => {
-      if (!service.referer?.address) {
-        log.warn("Hue bridge discovery: no address found", service.host);
-        return;
+    let hubItems: { id: string }[] = [];
+
+    if (msg instanceof uc.UserDataResponse && msg.inputValues.address) {
+      if (msg.inputValues.address.length > 0) {
+        log.debug("Starting manual hub setup for: %s", msg.inputValues.address);
+        this.manualAddress = true;
+        try {
+          this.hueApi.setBaseUrl(getHubUrl(msg.inputValues.address));
+          const hubConfig = await this.hueApi.getHubConfig();
+
+          if (this.cfgAddDevice && this.config.getHubConfig()?.bridgeId === hubConfig.bridgeid) {
+            // Prepared for multiple hubs: should not happen since only one Hub is supported at the moment.
+            log.info("Hub already configured, skipping manuel device %s", hubConfig.bridgeid);
+          } else {
+            const hub: HueHub = {
+              id: hubConfig.bridgeid,
+              ip: msg.inputValues.address,
+              name: hubConfig.name
+            };
+            this.hubs.push(hub);
+          }
+        } catch (e) {
+          log.warn("Failed to connect to hub", e);
+          return new uc.SetupError(uc.IntegrationSetupError.ConnectionRefused); // no better error at the moment :-(
+        }
       }
-      const hub: HueHub = {
-        id: service.host,
-        ip: service.referer?.address,
-        name: service.name
-      };
-      this.hubs.push(hub);
-    });
+    }
 
-    await delay(4000);
+    if (!this.manualAddress) {
+      log.info("Starting mDNS discovery of Hue hubs on the network");
 
-    if (this.hubs.length > 0) {
-      log.info("Hue bridge discovery: found hubs", this.hubs);
-      const hubItems = this.hubs.map((hub) => ({
+      this.bonjour.find({ type: "hue" }, (service) => {
+        // TODO verify if this is the correct address
+        if (!service.referer?.address) {
+          log.warn("Hue bridge discovery: no address found", service.host);
+          return;
+        }
+
+        const hub: HueHub = {
+          id: service.host,
+          ip: service.referer?.address,
+          name: service.name
+        };
+        this.hubs.push(hub);
+      });
+
+      await delay(4000);
+    }
+
+    if (this.hubs.length === 0) {
+      log.info("Could not discover any new hubs");
+      // Show try again / abort
+      return new uc.RequestUserConfirmation(
+        i18all("setup.discovery_failed.title"),
+        i18all("setup.discovery_failed.header")
+      );
+    } else {
+      // verify each discovered hub: only v2 hubs are supported
+      const filteredHubs = this.hubs.filter(async (hub) => {
+        try {
+          log.debug("Found hub %s: checking if it is a v2 bridge", hub.ip);
+          this.hueApi.setBaseUrl(getHubUrl(hub.ip));
+          await this.hueApi.is_hue_bridge();
+          if (!(await this.hueApi.is_v2_bridge())) {
+            log.warn("Hub %s is not a v2 bridge, skipping", hub.ip);
+            return false;
+          }
+        } catch (e) {
+          log.warn("Hub %s is either not a Hue bridge, or connection failed: %s", hub.ip, e);
+          return false;
+        }
+        return true;
+      });
+
+      log.info("Hue bridge discovery: found v2 hubs", filteredHubs);
+
+      hubItems = filteredHubs.map((hub) => ({
         id: hub.id,
         label: { en: hub.name },
         description: { en: `IP: ${hub.ip}` }
       }));
-      return new RequestUserInput("Select a Philips Hue hub", [
-        {
-          id: "hubId",
-          label: { en: "Discovered hubs" },
-          field: {
-            dropdown: {
-              value: hubItems[0].id,
-              items: hubItems
-            }
-          }
-        }
-      ]);
     }
 
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        log.warn("Hue bridge discovery timed out");
-        resolve(new SetupError("Hue bridge discovery timed out"));
-      }, 10000);
-    });
+    this.setupStep = SetupSteps.DEVICE_CHOICE;
+    return new RequestUserInput(i18all("setup.discovery.discovered_title"), [
+      {
+        id: "hubId",
+        label: i18all("setup.discovery.discovered_hubs"),
+        field: {
+          dropdown: {
+            value: hubItems[0].id,
+            items: hubItems
+          }
+        }
+      }
+    ]);
   }
 }
 


### PR DESCRIPTION
# Description

Add manual setup options to configure a Hue hub by IP address. New option in setup flow to show hub configuration and light resources.

Other fixes and changes:
- Only support v2 Hue hubs
- Add i18n
- Refactor Hue API class
- Fix eslint settings for TS
- Remove no-longer used node-hue-api dependency

Closes #18 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests with a v2 hub: manually configuring a hub
