### PR TITLE
Fix incorrect address and IP in setup process

### DIFF
--- a/src/lib/hue-api/api.ts
+++ b/src/lib/hue-api/api.ts
@@ -148,7 +148,7 @@ class HueApi implements ResourceApi {
       throw new HueError("Failed to generate auth key: Hub URL is required", StatusCodes.ServiceUnavailable);
     }
     try {
-      const { data } = await this.axiosInstance.post<AuthenticateResult[]>(`${this.hubUrl}/api`, {
+      const { data } = await this.axiosInstance.post<AuthenticateResult[]>(`/api`, {
         devicetype: deviceType,
         generateclientkey: true
       });


### PR DESCRIPTION
# Description

Fixes two issues in the setup process:
- Discovery used the gateway/referrer IP instead of the hub's IP
- URL for getting token had the hub address added twice

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested by running the integration locally and setting up my hub on the remote with added entities.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request represents one logical piece of work. Do not combine multiple unrelated changes into a single pull request.
- [x] My changes pass the linter tests `npm run code-check`. PRs with failing linter checks will not be merged.
- [x] I have tested and performed a self-review of my code

