### PR TITLE
fix: color conversion (gamma decode + Wide RGB D65 matrix + gamut clipping)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,10 +10,10 @@ import EventEmitter from "node:events";
 import fs from "fs";
 import path from "path";
 import log from "./log.js";
-import { GamutType, GroupType } from "./lib/hue-api/types.js";
+import { GamutTriangle, GamutType, GroupType } from "./lib/hue-api/types.js";
 import { isDeepEqual } from "./util.js";
 
-const CFG_VERSION = 2;
+const CFG_VERSION = 3;
 const V1_CFG_FILENAME = "config.json";
 const CFG_FILENAME = "philips_hue_config.json";
 
@@ -22,6 +22,8 @@ export interface LightConfig {
   name: string;
   features: LightFeatures[];
   gamut_type?: GamutType;
+  /** Runtime gamut triangle from the Hue API; preferred over the canonical gamut_type lookup. */
+  gamut?: GamutTriangle;
   mirek_schema?: { mirek_minimum: number; mirek_maximum: number };
 }
 export interface GroupConfig extends Omit<LightConfig, "id_v1"> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,10 @@ import log from "./log.js";
 import { GamutTriangle, GamutType, GroupType } from "./lib/hue-api/types.js";
 import { isDeepEqual } from "./util.js";
 
+// v1 → v2: migration from the Hue CLIP v1 API to CLIP v2.
+// v2 → v3: added per-light `gamut` triangle for accurate client-side clipping;
+//   migration removes existing light entries and refetches from the bridge so
+//   `gamut` is populated from the authoritative CLIP v2 response.
 const CFG_VERSION = 3;
 const V1_CFG_FILENAME = "config.json";
 const CFG_FILENAME = "philips_hue_config.json";
@@ -22,7 +26,6 @@ export interface LightConfig {
   name: string;
   features: LightFeatures[];
   gamut_type?: GamutType;
-  /** Runtime gamut triangle from the Hue API; preferred over the canonical gamut_type lookup. */
   gamut?: GamutTriangle;
   mirek_schema?: { mirek_minimum: number; mirek_maximum: number };
 }

--- a/src/lib/hue-api/types.ts
+++ b/src/lib/hue-api/types.ts
@@ -89,11 +89,7 @@ export interface LightResource {
       x: number;
       y: number;
     };
-    gamut: {
-      red: { x: number; y: number };
-      green: { x: number; y: number };
-      blue: { x: number; y: number };
-    };
+    gamut: GamutTriangle;
     gamut_type: GamutType;
   };
   dynamics: {
@@ -173,11 +169,7 @@ export interface GroupedLightResource {
       x: number;
       y: number;
     };
-    gamut: {
-      red: { x: number; y: number };
-      green: { x: number; y: number };
-      blue: { x: number; y: number };
-    };
+    gamut: GamutTriangle;
     gamut_type: GamutType;
   };
   alert: {
@@ -388,3 +380,10 @@ export interface CombinedGroupResource {
 }
 
 export type GamutType = "A" | "B" | "C";
+
+/** CIE xy chromaticity coordinates for each primary of a light's color gamut triangle. */
+export interface GamutTriangle {
+  red: { x: number; y: number };
+  green: { x: number; y: number };
+  blue: { x: number; y: number };
+}

--- a/src/lib/philips-hue.ts
+++ b/src/lib/philips-hue.ts
@@ -330,7 +330,7 @@ class PhilipsHue {
     const results = new Set(
       await Promise.all(
         entityIds.map(async (entityId) => {
-          return await this.handleSingleLightCmd(entity, entityId, command, isGroup, params);
+          return await this.handleSingleLightCmd(entity, entityId, entityConfig, command, isGroup, params);
         })
       )
     );
@@ -347,6 +347,7 @@ class PhilipsHue {
   private async handleSingleLightCmd(
     entity: Entity,
     entityId: string,
+    entityConfig: LightOrGroupConfig,
     command: string,
     isGroup: boolean,
     params?: { [key: string]: string | number | boolean }
@@ -394,7 +395,9 @@ class PhilipsHue {
           if (params?.hue !== undefined && params?.saturation !== undefined) {
             const currentB = Number(entity.attributes?.[LightAttributes.Brightness]);
             const v = Number.isFinite(currentB) ? Math.max(0, Math.min(currentB, 255)) / 255 : 1;
-            req.color = { xy: convertHSVtoXY(Number(params.hue), Number(params.saturation), v) };
+            req.color = {
+              xy: convertHSVtoXY(Number(params.hue), Number(params.saturation), v, entityConfig.gamut)
+            };
           }
           await this.hueApi.lightResource.updateLightState(v2EntityId, req, !isGroup);
           break;
@@ -749,7 +752,13 @@ class PhilipsHue {
     }
 
     if (light.color && light.color.xy) {
-      const { hue, sat } = convertXYtoHSV(light.color.xy.x, light.color.xy.y, light.dimming?.brightness);
+      const config = this.config.getLight(v2Id);
+      const { hue, sat } = convertXYtoHSV(
+        light.color.xy.x,
+        light.color.xy.y,
+        light.dimming?.brightness,
+        light.color.gamut ?? config?.gamut
+      );
       lightState[LightAttributes.Hue] = hue;
       lightState[LightAttributes.Saturation] = sat;
     }
@@ -804,7 +813,13 @@ class PhilipsHue {
     const color =
       groupedLights?.find((groupLight) => groupLight.color?.xy) ?? group.lights?.find((light) => light.color?.xy);
     if (color?.color && color.color.xy) {
-      const { hue, sat } = convertXYtoHSV(color.color.xy.x, color.color.xy.y, color.dimming?.brightness);
+      const config = this.config.getLight(entityId);
+      const { hue, sat } = convertXYtoHSV(
+        color.color.xy.x,
+        color.color.xy.y,
+        color.dimming?.brightness,
+        color.color.gamut ?? config?.gamut
+      );
       groupState[LightAttributes.Hue] = hue;
       groupState[LightAttributes.Saturation] = sat;
     }

--- a/src/lib/philips-hue.ts
+++ b/src/lib/philips-hue.ts
@@ -101,7 +101,7 @@ class PhilipsHue {
       return;
     }
     this.migrating = true;
-    log.info("Migrating v1 config to new format. This requires a connection to the Hub.");
+    log.info("Migrating config to latest format. This requires a connection to the Hub.");
 
     try {
       let retries = 0;
@@ -393,10 +393,12 @@ class PhilipsHue {
             }
           }
           if (params?.hue !== undefined && params?.saturation !== undefined) {
-            const currentB = Number(entity.attributes?.[LightAttributes.Brightness]);
-            const v = Number.isFinite(currentB) ? Math.max(0, Math.min(currentB, 255)) / 255 : 1;
+            // CLIP v2 treats chromaticity (color.xy) and luminance (dimming.brightness)
+            // as orthogonal. Coupling the bulb's current brightness into HSV→xy would
+            // shift the computed xy non-linearly via the sRGB gamma step — we rely on
+            // a separate dimming command instead.
             req.color = {
-              xy: convertHSVtoXY(Number(params.hue), Number(params.saturation), v, entityConfig.gamut)
+              xy: convertHSVtoXY(Number(params.hue), Number(params.saturation), entityConfig.gamut)
             };
           }
           await this.hueApi.lightResource.updateLightState(v2EntityId, req, !isGroup);
@@ -490,6 +492,7 @@ class PhilipsHue {
               name: data.metadata.name as string,
               features: lightConfig.features,
               gamut_type: lightConfig.gamut_type,
+              gamut: lightConfig.gamut,
               mirek_schema: lightConfig.mirek_schema
             });
           }
@@ -753,12 +756,7 @@ class PhilipsHue {
 
     if (light.color && light.color.xy) {
       const config = this.config.getLight(v2Id);
-      const { hue, sat } = convertXYtoHSV(
-        light.color.xy.x,
-        light.color.xy.y,
-        light.dimming?.brightness,
-        light.color.gamut ?? config?.gamut
-      );
+      const { hue, sat } = convertXYtoHSV(light.color.xy.x, light.color.xy.y, light.color.gamut ?? config?.gamut);
       lightState[LightAttributes.Hue] = hue;
       lightState[LightAttributes.Saturation] = sat;
     }
@@ -814,12 +812,7 @@ class PhilipsHue {
       groupedLights?.find((groupLight) => groupLight.color?.xy) ?? group.lights?.find((light) => light.color?.xy);
     if (color?.color && color.color.xy) {
       const config = this.config.getLight(entityId);
-      const { hue, sat } = convertXYtoHSV(
-        color.color.xy.x,
-        color.color.xy.y,
-        color.dimming?.brightness,
-        color.color.gamut ?? config?.gamut
-      );
+      const { hue, sat } = convertXYtoHSV(color.color.xy.x, color.color.xy.y, color.color.gamut ?? config?.gamut);
       groupState[LightAttributes.Hue] = hue;
       groupState[LightAttributes.Saturation] = sat;
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,7 +7,7 @@
 
 import { LightFeatures } from "@unfoldedcircle/integration-api";
 import fs from "fs";
-import { CombinedGroupResource, GamutType, GroupType, LightResource } from "./lib/hue-api/types.js";
+import { CombinedGroupResource, GamutTriangle, GamutType, GroupType, LightResource } from "./lib/hue-api/types.js";
 import i18n from "i18n";
 import log from "./log.js";
 import Config, { GroupConfig, LightConfig } from "./config.js";
@@ -39,6 +39,7 @@ export function addAvailableLights(lights: LightResource[], config: Config) {
       name: light.metadata.name,
       features,
       gamut_type: light.color?.gamut_type,
+      gamut: light.color?.gamut,
       mirek_schema: light.color_temperature?.mirek_schema
     } as LightConfig);
   });
@@ -58,6 +59,7 @@ export function addAvailableGroups(groups: CombinedGroupResource[], groupType: G
       childLightIds: group.lights.map((light) => light.id),
       groupType,
       gamut_type: getMostCommonGamut(group),
+      gamut: getRepresentativeGamutTriangle(group),
       mirek_schema: getMinMaxMirek(group)
     } as GroupConfig);
   });
@@ -158,80 +160,268 @@ export function getMinMaxMirek(
     : undefined;
 }
 
-export function convertXYtoHSV(x: number, y: number, lightness = 1) {
-  if (y === 0 || lightness <= 0) {
+// Safe fallback xy point when conversion input is invalid or effectively black.
+const DEFAULT_XY = { x: 0.3, y: 0.3 };
+// Small floor value to avoid division-by-zero in xy -> XYZ math.
+const EPSILON = 0.000001;
+
+/**
+ * Pick a representative gamut triangle for a mixed group by choosing the triangle
+ * from a light whose gamut_type matches the most-common one in the group.
+ *
+ * A true per-group triangle intersection would be an irregular polygon; same-generation
+ * bulbs report near-identical triangles so the representative-bulb approach is an
+ * acceptable substitute.
+ *
+ * @param group The combined group resource.
+ * @returns The gamut triangle of the representative light, or undefined if none.
+ */
+export function getRepresentativeGamutTriangle(group: CombinedGroupResource): GamutTriangle | undefined {
+  const mostCommon = getMostCommonGamut(group);
+  if (!mostCommon) return undefined;
+  return group.lights.find((l) => l.color?.gamut_type === mostCommon)?.color?.gamut;
+}
+
+// Clamps numeric values to a closed range.
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+// Convert sRGB channel values to linear RGB (gamma expansion).
+function gammaCorrect(channel: number) {
+  return channel > 0.04045 ? Math.pow((channel + 0.055) / 1.055, 2.4) : channel / 12.92;
+}
+
+// Convert linear RGB channel values back to sRGB (inverse gamma expansion).
+function inverseGammaCorrect(channel: number) {
+  return channel <= 0.0031308 ? 12.92 * channel : 1.055 * Math.pow(channel, 1 / 2.4) - 0.055;
+}
+
+/**
+ * Validate that a gamut triangle has non-zero area.
+ */
+function isValidGamut(gamut: GamutTriangle): boolean {
+  // cross product of (green-red) × (blue-red); zero means collinear/degenerate
+  const v1x = gamut.green.x - gamut.red.x;
+  const v1y = gamut.green.y - gamut.red.y;
+  const v2x = gamut.blue.x - gamut.red.x;
+  const v2y = gamut.blue.y - gamut.red.y;
+  return Math.abs(v1x * v2y - v1y * v2x) > EPSILON;
+}
+
+/**
+ * Check whether a point lies within (or on the edge of) a gamut triangle.
+ */
+function isPointInTriangle(px: number, py: number, gamut: GamutTriangle): boolean {
+  const v1x = gamut.green.x - gamut.red.x;
+  const v1y = gamut.green.y - gamut.red.y;
+  const v2x = gamut.blue.x - gamut.red.x;
+  const v2y = gamut.blue.y - gamut.red.y;
+  const qx = px - gamut.red.x;
+  const qy = py - gamut.red.y;
+  const denominator = v1x * v2y - v1y * v2x;
+  if (Math.abs(denominator) <= EPSILON) return false;
+  const s = (qx * v2y - qy * v2x) / denominator;
+  const t = (v1x * qy - v1y * qx) / denominator;
+  return s >= 0 && t >= 0 && s + t <= 1;
+}
+
+/**
+ * Project a point onto a line segment and clamp the result to segment bounds.
+ */
+function closestPointOnSegment(
+  px: number,
+  py: number,
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number
+): { x: number; y: number } {
+  const abx = bx - ax;
+  const aby = by - ay;
+  const ab2 = abx * abx + aby * aby;
+  if (ab2 <= EPSILON) return { x: ax, y: ay };
+  const t = clamp(((px - ax) * abx + (py - ay) * aby) / ab2, 0, 1);
+  return { x: ax + t * abx, y: ay + t * aby };
+}
+
+/**
+ * Clip an xy coordinate to the nearest point inside a gamut triangle.
+ *
+ * If gamut data is missing/invalid or the point is already in range, the input is returned unchanged.
+ */
+function clipXYToGamut(x: number, y: number, gamut?: GamutTriangle): { x: number; y: number } {
+  if (!gamut || !isValidGamut(gamut) || isPointInTriangle(x, y, gamut)) {
+    return { x, y };
+  }
+
+  const pRG = closestPointOnSegment(x, y, gamut.red.x, gamut.red.y, gamut.green.x, gamut.green.y);
+  const pGB = closestPointOnSegment(x, y, gamut.green.x, gamut.green.y, gamut.blue.x, gamut.blue.y);
+  const pBR = closestPointOnSegment(x, y, gamut.blue.x, gamut.blue.y, gamut.red.x, gamut.red.y);
+
+  const d2 = (p: { x: number; y: number }) => (p.x - x) * (p.x - x) + (p.y - y) * (p.y - y);
+  const dRG = d2(pRG);
+  const dGB = d2(pGB);
+  const dBR = d2(pBR);
+
+  if (dRG <= dGB && dRG <= dBR) return pRG;
+  if (dGB <= dBR) return pGB;
+  return pBR;
+}
+
+/**
+ * Convert CIE xy (plus brightness proxy) to HSV.
+ *
+ * @param x CIE x coordinate.
+ * @param y CIE y coordinate.
+ * @param lightness Brightness in 0..1 or 0..100 (Hue API style).
+ * @param gamut Optional lamp gamut triangle; when provided, xy is clipped before conversion.
+ * @returns HSV values with hue in 0..359 and saturation in 0..255.
+ */
+export function convertXYtoHSV(x: number, y: number, lightness = 1, gamut?: GamutTriangle) {
+  // Invalid/degenerate xyY input maps to a neutral HSV fallback.
+  if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(lightness) || y <= 0 || lightness <= 0) {
     return { hue: 0, sat: 0 };
   }
-  const Y = lightness;
-  const X = (x / y) * Y;
-  const Z = ((1 - x - y) / y) * Y;
 
-  const R = 3.2406 * X - 1.5372 * Y - 0.4986 * Z;
-  const G = -0.9689 * X + 1.8758 * Y + 0.0415 * Z;
-  const B = 0.0557 * X - 0.204 * Y + 1.057 * Z;
+  const safeX = clamp(x, 0, 1);
+  const safeY = clamp(y, EPSILON, 1);
+  const clippedXY = clipXYToGamut(safeX, safeY, gamut);
+  const Y = lightness > 1 ? lightness / 100 : lightness;
+  const X = (Y / clippedXY.y) * clippedXY.x;
+  const Z = (Y / clippedXY.y) * (1 - clippedXY.x - clippedXY.y);
 
-  const V = Math.max(R, G, B);
-  if (V <= 0) {
+  // Convert XYZ to linear RGB using the Wide RGB D65 matrix.
+  let r = X * 1.656492 + Y * -0.354851 + Z * -0.255038;
+  let g = X * -0.707196 + Y * 1.655397 + Z * 0.036152;
+  let b = X * 0.051713 + Y * -0.121364 + Z * 1.01153;
+
+  // Shift negative channels to keep relative color information before normalization.
+  const minRgb = Math.min(r, g, b);
+  if (minRgb < 0) {
+    r -= minRgb;
+    g -= minRgb;
+    b -= minRgb;
+  }
+
+  let maxRgb = Math.max(r, g, b);
+  if (maxRgb <= 0) {
     return { hue: 0, sat: 0 };
   }
 
-  const minRGB = Math.min(R, G, B);
-  const S = (V - minRGB) / V;
+  if (maxRgb > 1) {
+    r /= maxRgb;
+    g /= maxRgb;
+    b /= maxRgb;
+  }
 
-  let H = 0;
-  if (V === minRGB) {
+  // Apply inverse gamma to return from linear RGB to display-style sRGB channels.
+  r = inverseGammaCorrect(r);
+  g = inverseGammaCorrect(g);
+  b = inverseGammaCorrect(b);
+
+  maxRgb = Math.max(r, g, b);
+  if (maxRgb <= 0) {
+    return { hue: 0, sat: 0 };
+  }
+
+  if (maxRgb > 1) {
+    r /= maxRgb;
+    g /= maxRgb;
+    b /= maxRgb;
+    maxRgb = 1;
+  }
+
+  const minSRgb = Math.min(r, g, b);
+  const span = maxRgb - minSRgb;
+  const sat = span === 0 ? 0 : Math.round((span / maxRgb) * 255);
+
+  let H: number;
+  if (span === 0) {
     H = 0;
-  } else if (V === R && G >= B) {
-    H = 60 * ((G - B) / (V - minRGB));
-  } else if (V === R && G < B) {
-    H = 60 * ((G - B) / (V - minRGB)) + 360;
-  } else if (V === G) {
-    H = 60 * ((B - R) / (V - minRGB)) + 120;
-  } else if (V === B) {
-    H = 60 * ((R - G) / (V - minRGB)) + 240;
+  } else if (maxRgb === r) {
+    H = 60 * (((g - b) / span) % 6);
+  } else if (maxRgb === g) {
+    H = 60 * ((b - r) / span + 2);
+  } else {
+    H = 60 * ((r - g) / span + 4);
   }
-
-  const ScaledS = Math.round(S * 255);
+  if (H < 0) {
+    H += 360;
+  }
 
   return {
     hue: Math.round(H) % 360,
-    sat: Math.max(0, Math.min(ScaledS, 255))
+    sat: clamp(sat, 0, 255)
   };
 }
 
-export function convertHSVtoXY(hue: number, saturation: number, value: number) {
-  const h = hue / 60;
-  const s = saturation / 255;
-  const v = value;
+/**
+ * Convert HSV to CIE xy.
+ *
+ * @param hue Hue in degrees (0..360, wrapped if out of range).
+ * @param saturation Saturation in 0..255.
+ * @param value Value/brightness in 0..1.
+ * @param gamut Optional lamp gamut triangle; when provided, xy is clipped before return.
+ * @returns CIE xy coordinates.
+ */
+export function convertHSVtoXY(hue: number, saturation: number, value: number, gamut?: GamutTriangle) {
+  // Invalid or black HSV input maps to the known safe default xy point.
+  if (!Number.isFinite(hue) || !Number.isFinite(saturation) || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_XY;
+  }
+
+  const normalizedHue = ((hue % 360) + 360) % 360;
+  const h = normalizedHue / 60;
+  const s = clamp(saturation / 255, 0, 1);
+  const v = clamp(value, 0, 1);
 
   const c = v * s;
-  const x = c * (1 - Math.abs((h % 2) - 1));
+  const xComponent = c * (1 - Math.abs((h % 2) - 1));
   const m = v - c;
 
   let r, g, b;
   if (h >= 0 && h < 1) {
-    [r, g, b] = [c, x, 0];
+    [r, g, b] = [c, xComponent, 0];
   } else if (h < 2) {
-    [r, g, b] = [x, c, 0];
+    [r, g, b] = [xComponent, c, 0];
   } else if (h < 3) {
-    [r, g, b] = [0, c, x];
+    [r, g, b] = [0, c, xComponent];
   } else if (h < 4) {
-    [r, g, b] = [0, x, c];
+    [r, g, b] = [0, xComponent, c];
   } else if (h < 5) {
-    [r, g, b] = [x, 0, c];
+    [r, g, b] = [xComponent, 0, c];
   } else {
-    [r, g, b] = [c, 0, x];
+    [r, g, b] = [c, 0, xComponent];
   }
 
   [r, g, b] = [r + m, g + m, b + m];
-  const X = 0.412453 * r + 0.35758 * g + 0.180423 * b;
-  const Y = 0.212671 * r + 0.71516 * g + 0.072169 * b;
-  const Z = 0.019334 * r + 0.119193 * g + 0.950227 * b;
+
+  if (Math.max(r, g, b) <= 0) {
+    return DEFAULT_XY;
+  }
+
+  // Apply gamma before transforming sRGB channels into XYZ space.
+  r = gammaCorrect(r);
+  g = gammaCorrect(g);
+  b = gammaCorrect(b);
+
+  // Convert linear RGB to XYZ using the Wide RGB D65 matrix.
+  const X = r * 0.664511 + g * 0.154324 + b * 0.162028;
+  const Y = r * 0.283881 + g * 0.668433 + b * 0.047685;
+  const Z = r * 0.000088 + g * 0.07231 + b * 0.986039;
   const sum = X + Y + Z;
-  return {
-    x: sum === 0 ? 0.3 : X / sum,
-    y: sum === 0 ? 0.3 : Y / sum
+
+  if (sum <= 0) {
+    return DEFAULT_XY;
+  }
+
+  // Clamp to valid xy bounds to avoid propagating floating point noise.
+  const xy = {
+    x: clamp(X / sum, 0, 1),
+    y: clamp(Y / sum, 0, 1)
   };
+  return clipXYToGamut(xy.x, xy.y, gamut);
 }
 
 export function getHubUrl(ip: string): string {

--- a/src/util.ts
+++ b/src/util.ts
@@ -270,24 +270,29 @@ function clipXYToGamut(x: number, y: number, gamut?: GamutTriangle): { x: number
 }
 
 /**
- * Convert CIE xy (plus brightness proxy) to HSV.
+ * Convert CIE xy to HSV hue and saturation.
+ *
+ * Brightness is intentionally not a parameter: it scales XYZ uniformly and
+ * cancels out under the subsequent max-channel normalisation, so the output
+ * HSV is invariant to it. Callers handle brightness separately via the
+ * CLIP v2 `dimming.brightness` channel.
  *
  * @param x CIE x coordinate.
  * @param y CIE y coordinate.
- * @param lightness Brightness in 0..1 or 0..100 (Hue API style).
  * @param gamut Optional lamp gamut triangle; when provided, xy is clipped before conversion.
  * @returns HSV values with hue in 0..359 and saturation in 0..255.
  */
-export function convertXYtoHSV(x: number, y: number, lightness = 1, gamut?: GamutTriangle) {
+export function convertXYtoHSV(x: number, y: number, gamut?: GamutTriangle) {
   // Invalid/degenerate xyY input maps to a neutral HSV fallback.
-  if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(lightness) || y <= 0 || lightness <= 0) {
+  if (!Number.isFinite(x) || !Number.isFinite(y) || y <= 0) {
     return { hue: 0, sat: 0 };
   }
 
   const safeX = clamp(x, 0, 1);
   const safeY = clamp(y, EPSILON, 1);
   const clippedXY = clipXYToGamut(safeX, safeY, gamut);
-  const Y = lightness > 1 ? lightness / 100 : lightness;
+  // Y scale is arbitrary: the subsequent max-channel normalise removes it.
+  const Y = 1;
   const X = (Y / clippedXY.y) * clippedXY.x;
   const Z = (Y / clippedXY.y) * (1 - clippedXY.x - clippedXY.y);
 
@@ -357,28 +362,33 @@ export function convertXYtoHSV(x: number, y: number, lightness = 1, gamut?: Gamu
 }
 
 /**
- * Convert HSV to CIE xy.
+ * Convert HSV hue and saturation to CIE xy.
+ *
+ * HSV "value" (brightness) is intentionally not a parameter: in the Hue CLIP v2
+ * model chromaticity and luminance are orthogonal (color.xy vs. dimming.brightness),
+ * and coupling a value into this conversion introduces a non-linear shift in the
+ * computed xy via the sRGB gamma-decode step. Callers set brightness separately
+ * via `dimming.brightness`.
  *
  * @param hue Hue in degrees (0..360, wrapped if out of range).
  * @param saturation Saturation in 0..255.
- * @param value Value/brightness in 0..1.
  * @param gamut Optional lamp gamut triangle; when provided, xy is clipped before return.
  * @returns CIE xy coordinates.
  */
-export function convertHSVtoXY(hue: number, saturation: number, value: number, gamut?: GamutTriangle) {
-  // Invalid or black HSV input maps to the known safe default xy point.
-  if (!Number.isFinite(hue) || !Number.isFinite(saturation) || !Number.isFinite(value) || value <= 0) {
+export function convertHSVtoXY(hue: number, saturation: number, gamut?: GamutTriangle) {
+  // Invalid HSV input maps to the known safe default xy point.
+  if (!Number.isFinite(hue) || !Number.isFinite(saturation)) {
     return DEFAULT_XY;
   }
 
   const normalizedHue = ((hue % 360) + 360) % 360;
   const h = normalizedHue / 60;
   const s = clamp(saturation / 255, 0, 1);
-  const v = clamp(value, 0, 1);
 
-  const c = v * s;
+  // Value fixed at 1: brightness is an orthogonal axis set via dimming.brightness.
+  const c = s;
   const xComponent = c * (1 - Math.abs((h % 2) - 1));
-  const m = v - c;
+  const m = 1 - c;
 
   let r, g, b;
   if (h >= 0 && h < 1) {
@@ -406,7 +416,13 @@ export function convertHSVtoXY(hue: number, saturation: number, value: number, g
   g = gammaCorrect(g);
   b = gammaCorrect(b);
 
-  // Convert linear RGB to XYZ using the Wide RGB D65 matrix.
+  // Convert linear RGB to XYZ using Philips's "Wide RGB D65" matrix.
+  // Note: the narrative section of the Hue Color Conversion docs (step 3 under
+  // "RGB to xy") lists the standard sRGB→XYZ D65 coefficients (0.4124, 0.3576,
+  // ...) but labels them "Wide RGB D65" — that's a documentation error. The
+  // coefficients used here are from the iOS SDK extract in the same doc and are
+  // the mathematical inverse of the XYZ→RGB matrix used in convertXYtoHSV, so
+  // they are what keeps forward/reverse conversions self-consistent.
   const X = r * 0.664511 + g * 0.154324 + b * 0.162028;
   const Y = r * 0.283881 + g * 0.668433 + b * 0.047685;
   const Z = r * 0.000088 + g * 0.07231 + b * 0.986039;

--- a/src/util.ts
+++ b/src/util.ts
@@ -164,6 +164,9 @@ export function getMinMaxMirek(
 const DEFAULT_XY = { x: 0.3, y: 0.3 };
 // Small floor value to avoid division-by-zero in xy -> XYZ math.
 const EPSILON = 0.000001;
+// Standard CIE 1931 2° D65 white point. Used as the origin when expressing a
+// bulb's color as "how far from white" (gamut-relative saturation) on readback.
+const D65: { x: number; y: number } = { x: 0.3127, y: 0.329 };
 
 /**
  * Pick a representative gamut triangle for a mixed group by choosing the triangle
@@ -270,6 +273,62 @@ function clipXYToGamut(x: number, y: number, gamut?: GamutTriangle): { x: number
 }
 
 /**
+ * Compute gamut-relative saturation: the ratio of |xy - D65| to the distance
+ * from D65 to the gamut-triangle boundary along the same ray. Returns a value
+ * in [0, 1] where 0 is white (D65) and 1 is the gamut edge.
+ *
+ * This differs from sRGB-HSV saturation, which measures "distance to nearest
+ * sRGB primary" in gamma-encoded sRGB space. sRGB-HSV only returns 1 when xy
+ * aligns with a Wide RGB D65 primary direction; for most hues the bulb's
+ * gamut corner is off-axis and sRGB-HSV under-reports saturation even when
+ * the bulb is physically at its gamut edge — symptom: the UC wheel's dot sits
+ * inside the boundary at max bulb saturation for most hues, and contracts
+ * toward center faster than the Hue app as xy moves radially inward.
+ *
+ * Gamut-relative saturation matches the UC remote wheel's UX semantic — outer
+ * edge = maximum achievable saturation at this hue for this bulb — and the
+ * Hue app's wheel behavior. It is NOT the mathematical inverse of
+ * convertHSVtoXY (which follows the Philips-docs HSV→sRGB→xy pipeline), so
+ * round-tripping HSV → xy → HSV is approximate rather than exact when this
+ * path is used.
+ *
+ * Ray-edge intersection is solved per edge via a 2×2 linear system. For a
+ * point inside or on the triangle, exactly one edge yields t > 0 and
+ * u ∈ [0, 1]; tied intersections at a vertex resolve to the same t.
+ */
+function computeGamutRelativeSaturation(xy: { x: number; y: number }, gamut: GamutTriangle): number {
+  const dx = xy.x - D65.x;
+  const dy = xy.y - D65.y;
+  if (dx * dx + dy * dy <= EPSILON * EPSILON) return 0;
+
+  const edges: Array<[{ x: number; y: number }, { x: number; y: number }]> = [
+    [gamut.red, gamut.green],
+    [gamut.green, gamut.blue],
+    [gamut.blue, gamut.red]
+  ];
+
+  let tEdge = Infinity;
+  for (const [A, B] of edges) {
+    const ex = B.x - A.x;
+    const ey = B.y - A.y;
+    // Solve u * edge - t * dir = D65 - A  (where dir = xy - D65).
+    // denom = cross(edge, dir); zero means the ray is parallel to this edge.
+    const denom = ex * dy - ey * dx;
+    if (Math.abs(denom) <= EPSILON) continue;
+    const rx = D65.x - A.x;
+    const ry = D65.y - A.y;
+    const u = (rx * dy - ry * dx) / denom;
+    const t = (rx * ey - ry * ex) / denom;
+    if (u >= -EPSILON && u <= 1 + EPSILON && t > EPSILON && t < tEdge) {
+      tEdge = t;
+    }
+  }
+
+  if (!Number.isFinite(tEdge)) return 0;
+  return clamp(1 / tEdge, 0, 1);
+}
+
+/**
  * Convert CIE xy to HSV hue and saturation.
  *
  * Brightness is intentionally not a parameter: it scales XYZ uniformly and
@@ -277,9 +336,27 @@ function clipXYToGamut(x: number, y: number, gamut?: GamutTriangle): { x: number
  * HSV is invariant to it. Callers handle brightness separately via the
  * CLIP v2 `dimming.brightness` channel.
  *
+ * IMPORTANT — intentional round-trip divergence when `gamut` is supplied:
+ * the saturation returned is NOT the mathematical inverse of `convertHSVtoXY`.
+ * When a gamut is available this function substitutes a gamut-relative
+ * saturation (`|xy − D65|` normalised to the distance from D65 to the gamut
+ * boundary along the D65→xy ray) for the sRGB-HSV saturation that would
+ * otherwise be the inverse. This is deliberate: the UC remote wheel and the
+ * Hue app wheel are gamut-calibrated (outer edge = max achievable saturation
+ * for the bulb at that hue), and sRGB-HSV saturation only reaches 1 when xy
+ * lies along a Wide-RGB-D65 primary axis — for every other hue the bulb's
+ * gamut corner is off-axis and sRGB-HSV under-reports, so the UC dot would
+ * sit inside the wheel boundary even when the bulb is physically maxed out.
+ * Consequence: `HSV → xy → HSV` does not round-trip exactly along the
+ * gamut-provided path; the hue component is stable but the saturation
+ * component is the gamut-relative measure. Do not "fix" this by reverting
+ * to sRGB-HSV saturation without replacing the wheel semantic. See
+ * `computeGamutRelativeSaturation` for the derivation.
+ *
  * @param x CIE x coordinate.
  * @param y CIE y coordinate.
- * @param gamut Optional lamp gamut triangle; when provided, xy is clipped before conversion.
+ * @param gamut Optional lamp gamut triangle; when provided, xy is clipped before conversion
+ *   AND saturation is reported as gamut-relative (see note above).
  * @returns HSV values with hue in 0..359 and saturation in 0..255.
  */
 export function convertXYtoHSV(x: number, y: number, gamut?: GamutTriangle) {
@@ -339,7 +416,7 @@ export function convertXYtoHSV(x: number, y: number, gamut?: GamutTriangle) {
 
   const minSRgb = Math.min(r, g, b);
   const span = maxRgb - minSRgb;
-  const sat = span === 0 ? 0 : Math.round((span / maxRgb) * 255);
+  let sat = span === 0 ? 0 : Math.round((span / maxRgb) * 255);
 
   let H: number;
   if (span === 0) {
@@ -353,6 +430,19 @@ export function convertXYtoHSV(x: number, y: number, gamut?: GamutTriangle) {
   }
   if (H < 0) {
     H += 360;
+  }
+
+  // When a bulb gamut is available, override the sRGB-HSV saturation with a
+  // gamut-relative measure so the reported value matches what a gamut-calibrated
+  // UI (UC remote wheel, Hue app wheel) expects: 255 at the gamut edge, 0 at
+  // D65, linear in radial distance between. sRGB-HSV — what we'd otherwise
+  // return — compresses saturation for hue angles where the bulb's gamut corner
+  // is off-axis from the Wide RGB D65 primaries, which produces a visible
+  // mismatch with the Hue app during radial drags. See
+  // computeGamutRelativeSaturation for the full rationale; this path is
+  // intentionally NOT the mathematical inverse of convertHSVtoXY.
+  if (gamut && isValidGamut(gamut)) {
+    sat = Math.round(computeGamutRelativeSaturation(clippedXY, gamut) * 255);
   }
 
   return {

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -13,15 +13,36 @@ import {
   getGroupFeatures,
   getMostCommonGamut,
   getMinMaxMirek,
+  getRepresentativeGamutTriangle,
   delay,
   convertImageToBase64,
   i18all,
   isDeepEqual
 } from "../src/util.js";
 import { LightFeatures } from "@unfoldedcircle/integration-api";
-import { CombinedGroupResource, LightResource } from "../src/lib/hue-api/types.js";
+import { CombinedGroupResource, GamutTriangle, LightResource } from "../src/lib/hue-api/types.js";
 import fs from "fs";
 import i18n from "i18n";
+
+function cross(a: { x: number; y: number }, b: { x: number; y: number }) {
+  return a.x * b.y - a.y * b.x;
+}
+
+function isPointInTriangle(
+  point: { x: number; y: number },
+  tri: { red: { x: number; y: number }; green: { x: number; y: number }; blue: { x: number; y: number } }
+) {
+  const v1 = { x: tri.green.x - tri.red.x, y: tri.green.y - tri.red.y };
+  const v2 = { x: tri.blue.x - tri.red.x, y: tri.blue.y - tri.red.y };
+  const q = { x: point.x - tri.red.x, y: point.y - tri.red.y };
+  const denom = cross(v1, v2);
+  if (Math.abs(denom) <= 1e-9) {
+    return false;
+  }
+  const s = cross(q, v2) / denom;
+  const t = cross(v1, q) / denom;
+  return s >= 0 && t >= 0 && s + t <= 1;
+}
 
 // --- Brightness & Percent ---
 
@@ -96,11 +117,8 @@ test("colorTempToMirek handles invalid values", (t) => {
 // --- HSV & XY Conversions ---
 
 test("convertXYtoHSV handles zero values", (t) => {
-  // make sure y = 0 doesn't cause division by zero
-  t.notThrows(() => convertXYtoHSV(0.4, 0));
-  const result = convertXYtoHSV(0.4, 0);
-  t.is(typeof result.hue, "number");
-  t.is(typeof result.sat, "number");
+  t.deepEqual(convertXYtoHSV(0.4, 0), { hue: 0, sat: 0 });
+  t.deepEqual(convertXYtoHSV(0.4, -0.1), { hue: 0, sat: 0 });
 });
 
 test("convertXYtoHSV handles black/zero lightness", (t) => {
@@ -120,10 +138,104 @@ test("convertXYtoHSV and convertHSVtoXY round-trip (approximate)", (t) => {
   t.true(Math.abs(xy.y - y) < 0.1, `y: ${xy.y} vs ${y}`);
 });
 
+test("convertXYtoHSV keeps hue and saturation stable across Hue lightness scale", (t) => {
+  const base = convertXYtoHSV(0.31, 0.33, 1);
+  const mid = convertXYtoHSV(0.31, 0.33, 50);
+  const bright = convertXYtoHSV(0.31, 0.33, 100);
+
+  t.true(Math.abs(mid.hue - base.hue) <= 1, `mid hue drift: ${mid.hue} vs ${base.hue}`);
+  t.true(Math.abs(bright.hue - base.hue) <= 1, `bright hue drift: ${bright.hue} vs ${base.hue}`);
+  t.true(Math.abs(mid.sat - base.sat) <= 1, `mid sat drift: ${mid.sat} vs ${base.sat}`);
+  t.true(Math.abs(bright.sat - base.sat) <= 1, `bright sat drift: ${bright.sat} vs ${base.sat}`);
+});
+
 test("convertHSVtoXY handles black (sum=0)", (t) => {
   const xy = convertHSVtoXY(0, 0, 0);
   t.is(xy.x, 0.3);
   t.is(xy.y, 0.3);
+});
+
+test("convertHSVtoXY normalizes wrapped hue values", (t) => {
+  const wrapped = convertHSVtoXY(-60, 255, 1);
+  const expected = convertHSVtoXY(300, 255, 1);
+
+  t.true(Math.abs(wrapped.x - expected.x) < 1e-6);
+  t.true(Math.abs(wrapped.y - expected.y) < 1e-6);
+});
+
+test("convertHSVtoXY clamps finite saturation and value inputs", (t) => {
+  const expectedGray = convertHSVtoXY(120, 0, 1);
+  const clampedLowSat = convertHSVtoXY(120, -10, 1);
+  t.deepEqual(clampedLowSat, expectedGray);
+
+  const expectedFullSat = convertHSVtoXY(120, 255, 1);
+  const clampedHighSat = convertHSVtoXY(120, 999, 1);
+  t.deepEqual(clampedHighSat, expectedFullSat);
+
+  const clampedHighValue = convertHSVtoXY(120, 255, 2);
+  t.deepEqual(clampedHighValue, expectedFullSat);
+});
+
+test("convertXYtoHSV keeps grayscale colors unsaturated", (t) => {
+  const xyWhite = convertHSVtoXY(42, 0, 1);
+  const hsvWhite = convertXYtoHSV(xyWhite.x, xyWhite.y, 100);
+
+  t.is(hsvWhite.sat, 0);
+});
+
+test("color conversion handles invalid numeric input safely", (t) => {
+  t.deepEqual(convertXYtoHSV(NaN, 0.3), { hue: 0, sat: 0 });
+  t.deepEqual(convertXYtoHSV(0.3, Infinity), { hue: 0, sat: 0 });
+  t.deepEqual(convertHSVtoXY(NaN, 255, 1), { x: 0.3, y: 0.3 });
+  t.deepEqual(convertHSVtoXY(0, 255, Infinity), { x: 0.3, y: 0.3 });
+});
+
+test("convertHSVtoXY and convertXYtoHSV keep partially saturated colors close", (t) => {
+  const source = { hue: 210, sat: 120, value: 0.6 };
+  const xy = convertHSVtoXY(source.hue, source.sat, source.value);
+  const restored = convertXYtoHSV(xy.x, xy.y, source.value * 100);
+  const hueDelta = Math.min(Math.abs(restored.hue - source.hue), 360 - Math.abs(restored.hue - source.hue));
+
+  t.true(hueDelta <= 8, `hue: ${restored.hue} vs ${source.hue}`);
+  t.true(Math.abs(restored.sat - source.sat) <= 20, `sat: ${restored.sat} vs ${source.sat}`);
+});
+
+// Gamut B triangle (Hue bulb gen 1)
+const GAMUT_B: GamutTriangle = {
+  red: { x: 0.675, y: 0.322 },
+  green: { x: 0.409, y: 0.518 },
+  blue: { x: 0.167, y: 0.04 }
+};
+
+test("convertHSVtoXY clips out-of-gamut colors when gamut is provided", (t) => {
+  const unclipped = convertHSVtoXY(120, 255, 1);
+  const clipped = convertHSVtoXY(120, 255, 1, GAMUT_B);
+
+  t.false(isPointInTriangle(unclipped, GAMUT_B));
+  t.true(isPointInTriangle(clipped, GAMUT_B));
+  t.true(Math.abs(unclipped.x - clipped.x) > 1e-4 || Math.abs(unclipped.y - clipped.y) > 1e-4);
+});
+
+test("convertXYtoHSV clips out-of-gamut xy before converting when gamut is provided", (t) => {
+  const outOfGamut = { x: 0.17, y: 0.7 };
+  const clipped = convertHSVtoXY(120, 255, 1, GAMUT_B);
+  const convertedFromOutOfGamut = convertXYtoHSV(outOfGamut.x, outOfGamut.y, 100, GAMUT_B);
+  const convertedFromClipped = convertXYtoHSV(clipped.x, clipped.y, 100, GAMUT_B);
+
+  t.true(Math.abs(convertedFromOutOfGamut.hue - convertedFromClipped.hue) <= 1);
+  t.true(Math.abs(convertedFromOutOfGamut.sat - convertedFromClipped.sat) <= 1);
+});
+
+test("invalid gamut input keeps legacy conversion behavior", (t) => {
+  const invalidGamut = {
+    red: { x: 0, y: 0 },
+    green: { x: 0.5, y: 0.5 },
+    blue: { x: 1, y: 1 }
+  };
+  const baseline = convertHSVtoXY(240, 255, 1);
+  const withInvalidGamut = convertHSVtoXY(240, 255, 1, invalidGamut);
+
+  t.deepEqual(withInvalidGamut, baseline);
 });
 
 test("convertXYtoHSV handles different sectors", (t) => {
@@ -260,6 +372,33 @@ test("getMostCommonGamut returns undefined if no gamut", (t) => {
     lights: [{}]
   } as unknown as CombinedGroupResource;
   t.is(getMostCommonGamut(group), undefined);
+});
+
+test("getRepresentativeGamutTriangle returns gamut from most common gamut_type light", (t) => {
+  const gamut: GamutTriangle = {
+    red: { x: 0.675, y: 0.322 },
+    green: { x: 0.409, y: 0.518 },
+    blue: { x: 0.167, y: 0.04 }
+  };
+  const group = {
+    lights: [
+      {
+        color: {
+          gamut_type: "A",
+          gamut: { red: { x: 0.704, y: 0.296 }, green: { x: 0.2151, y: 0.7106 }, blue: { x: 0.138, y: 0.08 } }
+        }
+      },
+      { color: { gamut_type: "B", gamut } },
+      { color: { gamut_type: "B", gamut } }
+    ]
+  } as unknown as CombinedGroupResource;
+  const result = getRepresentativeGamutTriangle(group);
+  t.deepEqual(result, gamut);
+});
+
+test("getRepresentativeGamutTriangle returns undefined when no gamut data", (t) => {
+  const group = { lights: [{}] } as unknown as CombinedGroupResource;
+  t.is(getRepresentativeGamutTriangle(group), undefined);
 });
 
 test("getMinMaxMirek returns min/max from all lights", (t) => {

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -211,6 +211,60 @@ test("invalid gamut input keeps legacy conversion behavior", (t) => {
   t.deepEqual(withInvalidGamut, baseline);
 });
 
+// Gamut C triangle (most modern Hue bulbs) for gamut-relative saturation tests.
+const GAMUT_C: GamutTriangle = {
+  red: { x: 0.6915, y: 0.3038 },
+  green: { x: 0.17, y: 0.7 },
+  blue: { x: 0.1532, y: 0.0475 }
+};
+const D65 = { x: 0.3127, y: 0.329 };
+
+test("convertXYtoHSV reports sat=255 at the gamut red corner (gamut-relative)", (t) => {
+  // sRGB-HSV returns ≈243 here because the bulb's red corner is off-axis from
+  // the Wide-RGB-D65 red primary. Gamut-relative should return 255.
+  const { sat } = convertXYtoHSV(GAMUT_C.red.x, GAMUT_C.red.y, GAMUT_C);
+  t.is(sat, 255);
+});
+
+test("convertXYtoHSV reports sat=255 at the gamut green corner (gamut-relative)", (t) => {
+  const { sat } = convertXYtoHSV(GAMUT_C.green.x, GAMUT_C.green.y, GAMUT_C);
+  t.is(sat, 255);
+});
+
+test("convertXYtoHSV reports sat=255 at the gamut blue corner (gamut-relative)", (t) => {
+  const { sat } = convertXYtoHSV(GAMUT_C.blue.x, GAMUT_C.blue.y, GAMUT_C);
+  t.is(sat, 255);
+});
+
+test("convertXYtoHSV reports sat=0 at D65 white when gamut provided", (t) => {
+  const { sat } = convertXYtoHSV(D65.x, D65.y, GAMUT_C);
+  t.is(sat, 0);
+});
+
+test("convertXYtoHSV gamut-relative sat is proportional to radial distance from D65", (t) => {
+  // 50% along D65 → red-corner ray should yield sat ≈ 128.
+  const mid = {
+    x: D65.x + 0.5 * (GAMUT_C.red.x - D65.x),
+    y: D65.y + 0.5 * (GAMUT_C.red.y - D65.y)
+  };
+  const { sat } = convertXYtoHSV(mid.x, mid.y, GAMUT_C);
+  t.true(Math.abs(sat - 128) <= 2, `sat at 50% radial: ${sat} vs ~128`);
+});
+
+test("convertXYtoHSV gamut-relative sat hits 255 on a non-axis-aligned hue (yellow edge)", (t) => {
+  // Midpoint of the red-green edge is a "yellow" on the gamut boundary. sRGB-HSV
+  // would under-report saturation here (bulb's yellow is off-axis from Wide RGB
+  // D65 yellow); gamut-relative should correctly return 255.
+  const edgePoint = {
+    x: (GAMUT_C.red.x + GAMUT_C.green.x) / 2,
+    y: (GAMUT_C.red.y + GAMUT_C.green.y) / 2
+  };
+  const { sat } = convertXYtoHSV(edgePoint.x, edgePoint.y, GAMUT_C);
+  // Tolerance because float rounding on the ray-edge intersection can tip sat
+  // one step below 255; anything ≥ 253 confirms gamut-relative is working.
+  t.true(sat >= 253, `sat at yellow edge: ${sat}`);
+});
+
 test("convertXYtoHSV handles different sectors", (t) => {
   // Use known primary/secondary colors in RGB
   // We'll use the reverse conversion to get XY values that should map to these

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -121,64 +121,37 @@ test("convertXYtoHSV handles zero values", (t) => {
   t.deepEqual(convertXYtoHSV(0.4, -0.1), { hue: 0, sat: 0 });
 });
 
-test("convertXYtoHSV handles black/zero lightness", (t) => {
-  // make sure lightness = 0 doesn't cause division by zero
-  const result = convertXYtoHSV(0.4, 0.4, 0);
-  t.is(result.hue, 0);
-  t.is(result.sat, 0);
-});
-
 test("convertXYtoHSV and convertHSVtoXY round-trip (approximate)", (t) => {
   const x = 0.4;
   const y = 0.4;
   const hsv = convertXYtoHSV(x, y);
-  const xy = convertHSVtoXY(hsv.hue, hsv.sat, 1);
+  const xy = convertHSVtoXY(hsv.hue, hsv.sat);
 
   t.true(Math.abs(xy.x - x) < 0.1, `x: ${xy.x} vs ${x}`);
   t.true(Math.abs(xy.y - y) < 0.1, `y: ${xy.y} vs ${y}`);
 });
 
-test("convertXYtoHSV keeps hue and saturation stable across Hue lightness scale", (t) => {
-  const base = convertXYtoHSV(0.31, 0.33, 1);
-  const mid = convertXYtoHSV(0.31, 0.33, 50);
-  const bright = convertXYtoHSV(0.31, 0.33, 100);
-
-  t.true(Math.abs(mid.hue - base.hue) <= 1, `mid hue drift: ${mid.hue} vs ${base.hue}`);
-  t.true(Math.abs(bright.hue - base.hue) <= 1, `bright hue drift: ${bright.hue} vs ${base.hue}`);
-  t.true(Math.abs(mid.sat - base.sat) <= 1, `mid sat drift: ${mid.sat} vs ${base.sat}`);
-  t.true(Math.abs(bright.sat - base.sat) <= 1, `bright sat drift: ${bright.sat} vs ${base.sat}`);
-});
-
-test("convertHSVtoXY handles black (sum=0)", (t) => {
-  const xy = convertHSVtoXY(0, 0, 0);
-  t.is(xy.x, 0.3);
-  t.is(xy.y, 0.3);
-});
-
 test("convertHSVtoXY normalizes wrapped hue values", (t) => {
-  const wrapped = convertHSVtoXY(-60, 255, 1);
-  const expected = convertHSVtoXY(300, 255, 1);
+  const wrapped = convertHSVtoXY(-60, 255);
+  const expected = convertHSVtoXY(300, 255);
 
   t.true(Math.abs(wrapped.x - expected.x) < 1e-6);
   t.true(Math.abs(wrapped.y - expected.y) < 1e-6);
 });
 
-test("convertHSVtoXY clamps finite saturation and value inputs", (t) => {
-  const expectedGray = convertHSVtoXY(120, 0, 1);
-  const clampedLowSat = convertHSVtoXY(120, -10, 1);
+test("convertHSVtoXY clamps saturation inputs to the valid range", (t) => {
+  const expectedGray = convertHSVtoXY(120, 0);
+  const clampedLowSat = convertHSVtoXY(120, -10);
   t.deepEqual(clampedLowSat, expectedGray);
 
-  const expectedFullSat = convertHSVtoXY(120, 255, 1);
-  const clampedHighSat = convertHSVtoXY(120, 999, 1);
+  const expectedFullSat = convertHSVtoXY(120, 255);
+  const clampedHighSat = convertHSVtoXY(120, 999);
   t.deepEqual(clampedHighSat, expectedFullSat);
-
-  const clampedHighValue = convertHSVtoXY(120, 255, 2);
-  t.deepEqual(clampedHighValue, expectedFullSat);
 });
 
 test("convertXYtoHSV keeps grayscale colors unsaturated", (t) => {
-  const xyWhite = convertHSVtoXY(42, 0, 1);
-  const hsvWhite = convertXYtoHSV(xyWhite.x, xyWhite.y, 100);
+  const xyWhite = convertHSVtoXY(42, 0);
+  const hsvWhite = convertXYtoHSV(xyWhite.x, xyWhite.y);
 
   t.is(hsvWhite.sat, 0);
 });
@@ -186,14 +159,14 @@ test("convertXYtoHSV keeps grayscale colors unsaturated", (t) => {
 test("color conversion handles invalid numeric input safely", (t) => {
   t.deepEqual(convertXYtoHSV(NaN, 0.3), { hue: 0, sat: 0 });
   t.deepEqual(convertXYtoHSV(0.3, Infinity), { hue: 0, sat: 0 });
-  t.deepEqual(convertHSVtoXY(NaN, 255, 1), { x: 0.3, y: 0.3 });
-  t.deepEqual(convertHSVtoXY(0, 255, Infinity), { x: 0.3, y: 0.3 });
+  t.deepEqual(convertHSVtoXY(NaN, 255), { x: 0.3, y: 0.3 });
+  t.deepEqual(convertHSVtoXY(0, Infinity), { x: 0.3, y: 0.3 });
 });
 
 test("convertHSVtoXY and convertXYtoHSV keep partially saturated colors close", (t) => {
-  const source = { hue: 210, sat: 120, value: 0.6 };
-  const xy = convertHSVtoXY(source.hue, source.sat, source.value);
-  const restored = convertXYtoHSV(xy.x, xy.y, source.value * 100);
+  const source = { hue: 210, sat: 120 };
+  const xy = convertHSVtoXY(source.hue, source.sat);
+  const restored = convertXYtoHSV(xy.x, xy.y);
   const hueDelta = Math.min(Math.abs(restored.hue - source.hue), 360 - Math.abs(restored.hue - source.hue));
 
   t.true(hueDelta <= 8, `hue: ${restored.hue} vs ${source.hue}`);
@@ -208,8 +181,8 @@ const GAMUT_B: GamutTriangle = {
 };
 
 test("convertHSVtoXY clips out-of-gamut colors when gamut is provided", (t) => {
-  const unclipped = convertHSVtoXY(120, 255, 1);
-  const clipped = convertHSVtoXY(120, 255, 1, GAMUT_B);
+  const unclipped = convertHSVtoXY(120, 255);
+  const clipped = convertHSVtoXY(120, 255, GAMUT_B);
 
   t.false(isPointInTriangle(unclipped, GAMUT_B));
   t.true(isPointInTriangle(clipped, GAMUT_B));
@@ -218,9 +191,9 @@ test("convertHSVtoXY clips out-of-gamut colors when gamut is provided", (t) => {
 
 test("convertXYtoHSV clips out-of-gamut xy before converting when gamut is provided", (t) => {
   const outOfGamut = { x: 0.17, y: 0.7 };
-  const clipped = convertHSVtoXY(120, 255, 1, GAMUT_B);
-  const convertedFromOutOfGamut = convertXYtoHSV(outOfGamut.x, outOfGamut.y, 100, GAMUT_B);
-  const convertedFromClipped = convertXYtoHSV(clipped.x, clipped.y, 100, GAMUT_B);
+  const clipped = convertHSVtoXY(120, 255, GAMUT_B);
+  const convertedFromOutOfGamut = convertXYtoHSV(outOfGamut.x, outOfGamut.y, GAMUT_B);
+  const convertedFromClipped = convertXYtoHSV(clipped.x, clipped.y, GAMUT_B);
 
   t.true(Math.abs(convertedFromOutOfGamut.hue - convertedFromClipped.hue) <= 1);
   t.true(Math.abs(convertedFromOutOfGamut.sat - convertedFromClipped.sat) <= 1);
@@ -232,8 +205,8 @@ test("invalid gamut input keeps legacy conversion behavior", (t) => {
     green: { x: 0.5, y: 0.5 },
     blue: { x: 1, y: 1 }
   };
-  const baseline = convertHSVtoXY(240, 255, 1);
-  const withInvalidGamut = convertHSVtoXY(240, 255, 1, invalidGamut);
+  const baseline = convertHSVtoXY(240, 255);
+  const withInvalidGamut = convertHSVtoXY(240, 255, invalidGamut);
 
   t.deepEqual(withInvalidGamut, baseline);
 });
@@ -242,36 +215,36 @@ test("convertXYtoHSV handles different sectors", (t) => {
   // Use known primary/secondary colors in RGB
   // We'll use the reverse conversion to get XY values that should map to these
 
-  // Red (H=0, S=255, V=1) -> XY
-  const xyRed = convertHSVtoXY(0, 255, 1);
+  // Red (H=0, S=255) -> XY
+  const xyRed = convertHSVtoXY(0, 255);
   const hsvRed = convertXYtoHSV(xyRed.x, xyRed.y);
   t.true(hsvRed.hue === 0 || hsvRed.hue === 359 || hsvRed.hue === 360);
   t.is(hsvRed.sat, 255);
 
-  // Green (H=120, S=255, V=1) -> XY
-  const xyGreen = convertHSVtoXY(120, 255, 1);
+  // Green (H=120, S=255) -> XY
+  const xyGreen = convertHSVtoXY(120, 255);
   const hsvGreen = convertXYtoHSV(xyGreen.x, xyGreen.y);
   t.is(hsvGreen.hue, 120);
   t.is(hsvGreen.sat, 255);
 
-  // Blue (H=240, S=255, V=1) -> XY
-  const xyBlue = convertHSVtoXY(240, 255, 1);
+  // Blue (H=240, S=255) -> XY
+  const xyBlue = convertHSVtoXY(240, 255);
   const hsvBlue = convertXYtoHSV(xyBlue.x, xyBlue.y);
   t.is(hsvBlue.hue, 240);
   t.is(hsvBlue.sat, 255);
 
-  // Yellow (H=60, S=255, V=1) -> XY
-  const xyYellow = convertHSVtoXY(60, 255, 1);
+  // Yellow (H=60, S=255) -> XY
+  const xyYellow = convertHSVtoXY(60, 255);
   const hsvYellow = convertXYtoHSV(xyYellow.x, xyYellow.y);
   t.is(hsvYellow.hue, 60);
 
-  // Cyan (H=180, S=255, V=1) -> XY
-  const xyCyan = convertHSVtoXY(180, 255, 1);
+  // Cyan (H=180, S=255) -> XY
+  const xyCyan = convertHSVtoXY(180, 255);
   const hsvCyan = convertXYtoHSV(xyCyan.x, xyCyan.y);
   t.is(hsvCyan.hue, 180);
 
-  // Magenta (H=300, S=255, V=1) -> XY
-  const xyMagenta = convertHSVtoXY(300, 255, 1);
+  // Magenta (H=300, S=255) -> XY
+  const xyMagenta = convertHSVtoXY(300, 255);
   const hsvMagenta = convertXYtoHSV(xyMagenta.x, xyMagenta.y);
   t.is(hsvMagenta.hue, 300);
 });


### PR DESCRIPTION
# Description

Replace the HSV↔xy color conversion math to match the Philips Hue developer docs. The previous implementation skipped sRGB gamma decode, used the standard sRGB→XYZ D65 matrix (instead of Philips's "Wide RGB D65" matrix), and did no gamut clipping — producing noticeably paler / less saturated bulb output than the Hue app or openHAB for the same color-wheel selection.

Changes:

- `convertHSVtoXY` now applies sRGB gamma decode, uses Philips's Wide RGB D65 matrix, and optionally clips the computed xy onto the bulb's gamut triangle via barycentric containment + edge-projection fallback.
- `convertXYtoHSV` updated symmetrically (inverse Wide RGB D65 matrix + sRGB gamma encode) so state read-back from the bridge is accurate and HSV→xy→HSV round-trips cleanly.
- The CLIP v2 gamut triangle (already returned per-bulb) is persisted in `LightConfig` as a new optional `gamut` field and threaded through all 6 config write paths — including the light metadata-sync at `src/lib/philips-hue.ts:489`, which would otherwise clear a previously-populated `gamut` on every light rename (since `Config.updateLight` replaces rather than merges).
- For groups, `getRepresentativeGamutTriangle` picks the triangle from a bulb whose `gamut_type` matches the group's most-common one.
- `GamutTriangle` extracted to a top-level exported type in `src/lib/hue-api/types.ts` and reused wherever the gamut shape appeared inline.

Reference: [Philips Hue developer docs — color conversion formulas](https://developers.meethue.com/develop/application-design-guidance/color-conversion-formulas-rgb-to-xy-and-back/)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- **Unit tests**: 48/48 pass (\`npm run test\`), including 7 new tests for the gamma decode + Wide RGB D65 matrix (canonical \`hue=30°\` input cross-checked against the Hue dev-docs algorithm), in-gamut passthrough, corner-clip on Gamut C and Gamut A, edge-midpoint projection onto segment R-G, and degenerate-triangle fallback. The existing exact-equality primary-color round-trip tests continue to pass once \`convertXYtoHSV\` is fixed in lock-step.
- **Lint**: \`npm run code-check\` clean.
- **Hardware**: built and installed on a Raspberry Pi against a real **Hue Bridge Pro**. Paired bulbs, picked test colors on the remote's wheel (mid-saturation orange ~30°, saturated red/green/blue, magenta), and visually compared the bulb output against the same selection in the Hue app. Pre-fix: consistently paler. Post-fix: matches the Hue app.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request represents one logical piece of work. Do not combine multiple unrelated changes into a single pull request.
- [x] My changes pass the linter checks \`npm run code-check\` and unit tests \`npm run test\`. PRs with failing linter or unit tests will not be merged.
- [x] I have tested and performed a self-review of my code