### PR TITLE
feat: add scene support (per-group Select)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-_Changes in the next release_
+### Added
+
+- Each Hue room/zone with scenes is exposed as a `Select` entity; `current_option` tracks the active scene via SSE ([#134](https://github.com/unfoldedcircle/integration-philipshue/pull/134)).
+
+### Changed
+
+- Configuration version bumped from 3 to 4; the migration now also fetches scenes ([#134](https://github.com/unfoldedcircle/integration-philipshue/pull/134)).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-_Changes in the next release_
+### Added
+
+- Hue scenes are exposed as `Button` entities, named `<Group> - <Scene>`. Push the
+  button to recall the scene; the bridge auto-starts dynamics when the scene has
+  `auto_dynamic: true`.
+- A driver-wide `Hue Scene Dynamics` switch entity. ON starts the active scene's
+  dynamic palette; OFF stops it. State follows whichever scene the bridge reports
+  as currently active (so it tracks scene activations from the Hue app and other
+  clients, not just the remote).
+
+### Changed
+
+- Configuration version bumped from 3 to 4. The migration fetches scenes from
+  `/clip/v2/resource/scene` alongside lights, rooms, and zones.
 
 ---
 

--- a/docs/hue-api.http
+++ b/docs/hue-api.http
@@ -39,6 +39,57 @@ hue-application-key: {{hue_api_key}}
 GET {{hue_bridge_url}}/clip/v2/resource/scene HTTP/1.1
 hue-application-key: {{hue_api_key}}
 
+> {%
+    // Extract the first scene ID for the next requests.
+    // To use it in the future, manually save it in `hue_scene_id` of your ###.env.json file.
+    client.test("Extract first scene", function() {
+        const body = response.body;
+
+        client.assert(body && Array.isArray(body.data) && body.data.length > 0, "No data found in response");
+
+        const firstScene = body.data.find(item => item.type === "scene");
+        client.assert(firstScene, "No resource with type 'scene' found in the data array");
+
+        client.global.set("hue_scene_id", firstScene.id);
+        client.log("Selected Scene ID: " + client.global.get("hue_scene_id"));
+    });
+%}
+
+### get a specific scene
+GET {{hue_bridge_url}}/clip/v2/resource/scene/{{hue_scene_id}} HTTP/1.1
+hue-application-key: {{hue_api_key}}
+
+### recall (activate) a scene
+### Bridge auto-starts dynamics when the scene has auto_dynamic: true.
+PUT {{hue_bridge_url}}/clip/v2/resource/scene/{{hue_scene_id}} HTTP/1.1
+hue-application-key: {{hue_api_key}}
+
+{
+  "recall": {
+    "action": "active"
+  }
+}
+
+### start the dynamic palette on the active scene
+PUT {{hue_bridge_url}}/clip/v2/resource/scene/{{hue_scene_id}} HTTP/1.1
+hue-application-key: {{hue_api_key}}
+
+{
+  "recall": {
+    "action": "dynamic_palette"
+  }
+}
+
+### stop the dynamic palette and freeze the scene at its current state
+PUT {{hue_bridge_url}}/clip/v2/resource/scene/{{hue_scene_id}} HTTP/1.1
+hue-application-key: {{hue_api_key}}
+
+{
+  "recall": {
+    "action": "static"
+  }
+}
+
 ### get rooms
 ### Rooms group devices and each device can only be part of one room.
 GET {{hue_bridge_url}}/clip/v2/resource/room HTTP/1.1

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,9 @@ import { isDeepEqual } from "./util.js";
 // v2 → v3: added per-light `gamut` triangle for accurate client-side clipping;
 //   migration removes existing light entries and refetches from the bridge so
 //   `gamut` is populated from the authoritative CLIP v2 response.
-const CFG_VERSION = 3;
+// v3 → v4: added persisted scene records; migration fetches `/resource/scene`
+//   alongside lights, rooms, and zones to populate the new `scenes` map.
+const CFG_VERSION = 4;
 const V1_CFG_FILENAME = "config.json";
 const CFG_FILENAME = "philips_hue_config.json";
 
@@ -36,18 +38,27 @@ export interface GroupConfig extends Omit<LightConfig, "id_v1"> {
 }
 export type LightOrGroupConfig = LightConfig | GroupConfig;
 
+export interface SceneConfig {
+  name: string;
+  groupId: string;
+  groupRtype: "room" | "zone";
+  groupName: string | undefined;
+}
+
 interface PhilipsHueConfig {
   cfg_version?: number;
   hub?: { name: string; ip: string; username: string; bridgeId: string };
   lights: { [key: string]: LightOrGroupConfig };
+  scenes?: { [key: string]: SceneConfig };
 }
 
 export type ConfigEvent =
   | { type: "light-added"; data: LightOrGroupConfig & { id: string } }
-  | { type: "light-updated"; data: LightOrGroupConfig & { id: string } };
+  | { type: "light-updated"; data: LightOrGroupConfig & { id: string } }
+  | { type: "scene-added"; data: SceneConfig & { id: string } };
 
 class Config extends EventEmitter {
-  private config: PhilipsHueConfig = { lights: {} };
+  private config: PhilipsHueConfig = { lights: {}, scenes: {} };
   private readonly configDir: string;
   private readonly cb?: (event: ConfigEvent) => void;
 
@@ -133,12 +144,54 @@ class Config extends EventEmitter {
     return this.config.lights[id];
   }
 
+  public addScene(id: string, scene: SceneConfig) {
+    this.scenesMap()[id] = scene;
+    this.saveToFile();
+    if (this.cb) {
+      this.cb({ type: "scene-added", data: { id, ...scene } });
+    }
+  }
+
+  public getScene(id: string): SceneConfig | undefined {
+    return this.scenesMap()[id];
+  }
+
+  public getScenes(): (SceneConfig & { id: string })[] {
+    return Object.entries(this.scenesMap()).map(([id, scene]) => ({ id, ...scene }));
+  }
+
+  public updateScene(id: string, scene: SceneConfig) {
+    const scenes = this.scenesMap();
+    if (scenes[id] && isDeepEqual(scenes[id], scene)) {
+      return;
+    }
+    scenes[id] = scene;
+    this.saveToFile();
+  }
+
+  public removeScene(id: string) {
+    delete this.scenesMap()[id];
+    this.saveToFile();
+  }
+
+  public removeScenes() {
+    this.config.scenes = {};
+    this.saveToFile();
+  }
+
+  private scenesMap(): { [key: string]: SceneConfig } {
+    if (!this.config.scenes) {
+      this.config.scenes = {};
+    }
+    return this.config.scenes;
+  }
+
   /**
    * Remove the Hue hub. Since only one hub is supported, the configuration is cleared.
    */
   public removeHub() {
     const bridgeId = this.config.hub?.bridgeId;
-    this.config = { cfg_version: CFG_VERSION, lights: {} };
+    this.config = { cfg_version: CFG_VERSION, lights: {}, scenes: {} };
     this.saveToFile();
     if (bridgeId) {
       this.emit("remove", bridgeId);
@@ -149,7 +202,7 @@ class Config extends EventEmitter {
    * Clear the hub and light configuration.
    */
   public clear() {
-    this.config = { cfg_version: CFG_VERSION, lights: {} };
+    this.config = { cfg_version: CFG_VERSION, lights: {}, scenes: {} };
     this.saveToFile();
     this.emit("remove", null);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,7 +39,6 @@ export interface GroupConfig extends Omit<LightConfig, "id_v1"> {
 export type LightOrGroupConfig = LightConfig | GroupConfig;
 
 export interface SceneConfig {
-  id_v1?: string;
   name: string;
   groupId: string;
   groupRtype: "room" | "zone";

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,9 @@ import { isDeepEqual } from "./util.js";
 // v2 → v3: added per-light `gamut` triangle for accurate client-side clipping;
 //   migration removes existing light entries and refetches from the bridge so
 //   `gamut` is populated from the authoritative CLIP v2 response.
-const CFG_VERSION = 3;
+// v3 → v4: added persisted scene records; migration fetches `/resource/scene`
+//   alongside lights, rooms, and zones to populate the new `scenes` map.
+const CFG_VERSION = 4;
 const V1_CFG_FILENAME = "config.json";
 const CFG_FILENAME = "philips_hue_config.json";
 
@@ -36,18 +38,28 @@ export interface GroupConfig extends Omit<LightConfig, "id_v1"> {
 }
 export type LightOrGroupConfig = LightConfig | GroupConfig;
 
+export interface SceneConfig {
+  id_v1?: string;
+  name: string;
+  groupId: string;
+  groupRtype: "room" | "zone";
+  groupName: string | undefined;
+}
+
 interface PhilipsHueConfig {
   cfg_version?: number;
   hub?: { name: string; ip: string; username: string; bridgeId: string };
   lights: { [key: string]: LightOrGroupConfig };
+  scenes?: { [key: string]: SceneConfig };
 }
 
 export type ConfigEvent =
   | { type: "light-added"; data: LightOrGroupConfig & { id: string } }
-  | { type: "light-updated"; data: LightOrGroupConfig & { id: string } };
+  | { type: "light-updated"; data: LightOrGroupConfig & { id: string } }
+  | { type: "scene-added"; data: SceneConfig & { id: string } };
 
 class Config extends EventEmitter {
-  private config: PhilipsHueConfig = { lights: {} };
+  private config: PhilipsHueConfig = { lights: {}, scenes: {} };
   private readonly configDir: string;
   private readonly cb?: (event: ConfigEvent) => void;
 
@@ -133,12 +145,54 @@ class Config extends EventEmitter {
     return this.config.lights[id];
   }
 
+  public addScene(id: string, scene: SceneConfig) {
+    this.scenesMap()[id] = scene;
+    this.saveToFile();
+    if (this.cb) {
+      this.cb({ type: "scene-added", data: { id, ...scene } });
+    }
+  }
+
+  public getScene(id: string): SceneConfig | undefined {
+    return this.scenesMap()[id];
+  }
+
+  public getScenes(): (SceneConfig & { id: string })[] {
+    return Object.entries(this.scenesMap()).map(([id, scene]) => ({ id, ...scene }));
+  }
+
+  public updateScene(id: string, scene: SceneConfig) {
+    const scenes = this.scenesMap();
+    if (scenes[id] && isDeepEqual(scenes[id], scene)) {
+      return;
+    }
+    scenes[id] = scene;
+    this.saveToFile();
+  }
+
+  public removeScene(id: string) {
+    delete this.scenesMap()[id];
+    this.saveToFile();
+  }
+
+  public removeScenes() {
+    this.config.scenes = {};
+    this.saveToFile();
+  }
+
+  private scenesMap(): { [key: string]: SceneConfig } {
+    if (!this.config.scenes) {
+      this.config.scenes = {};
+    }
+    return this.config.scenes;
+  }
+
   /**
    * Remove the Hue hub. Since only one hub is supported, the configuration is cleared.
    */
   public removeHub() {
     const bridgeId = this.config.hub?.bridgeId;
-    this.config = { cfg_version: CFG_VERSION, lights: {} };
+    this.config = { cfg_version: CFG_VERSION, lights: {}, scenes: {} };
     this.saveToFile();
     if (bridgeId) {
       this.emit("remove", bridgeId);
@@ -149,7 +203,7 @@ class Config extends EventEmitter {
    * Clear the hub and light configuration.
    */
   public clear() {
-    this.config = { cfg_version: CFG_VERSION, lights: {} };
+    this.config = { cfg_version: CFG_VERSION, lights: {}, scenes: {} };
     this.saveToFile();
     this.emit("remove", null);
   }

--- a/src/lib/hue-api/api.ts
+++ b/src/lib/hue-api/api.ts
@@ -13,6 +13,7 @@ import { delay, normalizeBridgeId } from "../../util.js";
 import LightResource from "./light-resource.js";
 import { AuthenticateResult, AuthenticateSuccess, HubConfig } from "./types.js";
 import GroupResource from "./group-resource.js";
+import SceneResource from "./scene-resource.js";
 
 const MAX_RETRIES = 3;
 
@@ -48,12 +49,14 @@ class HueApi implements ResourceApi {
   private hubUrl?: string;
   public readonly lightResource: LightResource;
   public readonly groupResource: GroupResource;
+  public readonly sceneResource: SceneResource;
   private axiosInstance: AxiosInstance;
 
   constructor(hubUrl?: string, requestTimeout: number = 1500) {
     this.hubUrl = hubUrl;
     this.lightResource = new LightResource(this);
     this.groupResource = new GroupResource(this, this.lightResource);
+    this.sceneResource = new SceneResource(this);
     this.axiosInstance = axios.create({
       baseURL: this.hubUrl,
       timeout: requestTimeout,

--- a/src/lib/hue-api/scene-resource.ts
+++ b/src/lib/hue-api/scene-resource.ts
@@ -1,0 +1,76 @@
+/**
+ * Philips Hue API for the Remote Two/3 integration driver.
+ *
+ * @copyright (c) 2024 by Unfolded Circle ApS.
+ * @license Mozilla Public License Version 2.0, see LICENSE for more details.
+ */
+
+import { HueError, ResourceApi } from "./api.js";
+import { StatusCodes } from "@unfoldedcircle/integration-api";
+import {
+  CombinedSceneResource,
+  SceneRecallResponse,
+  SceneResource as SceneResourceData,
+  SceneResourceResult
+} from "./types.js";
+
+class SceneResource {
+  private readonly api: ResourceApi;
+
+  constructor(api: ResourceApi) {
+    this.api = api;
+  }
+
+  public async getScenes(): Promise<CombinedSceneResource[]> {
+    const res = await this.api.sendRequest<SceneResourceResult>("GET", "/clip/v2/resource/scene");
+    if (!res.data || res.data.length === 0) {
+      return [];
+    }
+    return res.data.map((scene) => this.toCombined(scene));
+  }
+
+  public async getScene(id: string): Promise<CombinedSceneResource> {
+    const res = await this.api.sendRequest<SceneResourceResult>("GET", `/clip/v2/resource/scene/${id}`);
+    if (!res.data || res.data.length === 0) {
+      throw new HueError("Scene resource not found", StatusCodes.NotFound);
+    }
+    return this.toCombined(res.data[0]);
+  }
+
+  /**
+   * Recall a scene on the bridge. Lets the bridge pick the playback mode based on the scene's
+   * own configuration (e.g. `auto_dynamic`); we don't override it.
+   */
+  public async recall(id: string): Promise<SceneRecallResponse["data"]> {
+    const res = await this.api.sendRequest<SceneRecallResponse>("PUT", `/clip/v2/resource/scene/${id}`, {
+      recall: { action: "active" }
+    });
+    return res.data ?? [];
+  }
+
+  /**
+   * Return the scenes the bridge currently reports as playing, one per group at most.
+   *
+   * Used to seed each per-group Select's `current_option` on event-stream connect.
+   */
+  public async getActiveScenes(): Promise<{ id: string; groupId: string }[]> {
+    const res = await this.api.sendRequest<SceneResourceResult>("GET", "/clip/v2/resource/scene");
+    if (!res.data || res.data.length === 0) {
+      return [];
+    }
+    return res.data
+      .filter((scene) => scene.status?.active && scene.status.active !== "inactive")
+      .map((scene) => ({ id: scene.id, groupId: scene.group.rid }));
+  }
+
+  private toCombined(scene: SceneResourceData): CombinedSceneResource {
+    const rtype: "room" | "zone" = scene.group.rtype === "zone" ? "zone" : "room";
+    return {
+      id: scene.id,
+      name: scene.metadata.name,
+      group: { rid: scene.group.rid, rtype }
+    };
+  }
+}
+
+export default SceneResource;

--- a/src/lib/hue-api/scene-resource.ts
+++ b/src/lib/hue-api/scene-resource.ts
@@ -66,7 +66,6 @@ class SceneResource {
     const rtype: "room" | "zone" = scene.group.rtype === "zone" ? "zone" : "room";
     return {
       id: scene.id,
-      id_v1: scene.id_v1,
       name: scene.metadata.name,
       group: { rid: scene.group.rid, rtype },
       groupName: groupNameById.get(scene.group.rid)

--- a/src/lib/hue-api/scene-resource.ts
+++ b/src/lib/hue-api/scene-resource.ts
@@ -1,0 +1,77 @@
+/**
+ * Philips Hue API for the Remote Two/3 integration driver.
+ *
+ * @copyright (c) 2024 by Unfolded Circle ApS.
+ * @license Mozilla Public License Version 2.0, see LICENSE for more details.
+ */
+
+import { HueError, ResourceApi } from "./api.js";
+import { StatusCodes } from "@unfoldedcircle/integration-api";
+import {
+  CombinedSceneResource,
+  GroupResourceResponse,
+  SceneRecallAction,
+  SceneRecallBody,
+  SceneRecallResponse,
+  SceneResource as SceneResourceData,
+  SceneResourceResult
+} from "./types.js";
+
+class SceneResource {
+  private readonly api: ResourceApi;
+
+  constructor(api: ResourceApi) {
+    this.api = api;
+  }
+
+  public async getScenes(): Promise<CombinedSceneResource[]> {
+    const res = await this.api.sendRequest<SceneResourceResult>("GET", "/clip/v2/resource/scene");
+    if (!res.data || res.data.length === 0) {
+      return [];
+    }
+
+    const groupNameById = await this.fetchGroupNameMap();
+    return res.data.map((scene) => this.toCombined(scene, groupNameById));
+  }
+
+  public async getScene(id: string): Promise<CombinedSceneResource> {
+    const res = await this.api.sendRequest<SceneResourceResult>("GET", `/clip/v2/resource/scene/${id}`);
+    if (!res.data || res.data.length === 0) {
+      throw new HueError("Scene resource not found", StatusCodes.NotFound);
+    }
+
+    const groupNameById = await this.fetchGroupNameMap();
+    return this.toCombined(res.data[0], groupNameById);
+  }
+
+  public async recall(id: string, action: SceneRecallAction = "active"): Promise<SceneRecallResponse["data"]> {
+    const body: SceneRecallBody = { recall: { action } };
+    const res = await this.api.sendRequest<SceneRecallResponse>("PUT", `/clip/v2/resource/scene/${id}`, body);
+    return res.data ?? [];
+  }
+
+  private async fetchGroupNameMap(): Promise<Map<string, string>> {
+    const [rooms, zones] = await Promise.all([
+      this.api.sendRequest<GroupResourceResponse>("GET", "/clip/v2/resource/room"),
+      this.api.sendRequest<GroupResourceResponse>("GET", "/clip/v2/resource/zone")
+    ]);
+    const map = new Map<string, string>();
+    for (const group of [...(rooms.data ?? []), ...(zones.data ?? [])]) {
+      map.set(group.id, group.metadata.name);
+    }
+    return map;
+  }
+
+  private toCombined(scene: SceneResourceData, groupNameById: Map<string, string>): CombinedSceneResource {
+    const rtype: "room" | "zone" = scene.group.rtype === "zone" ? "zone" : "room";
+    return {
+      id: scene.id,
+      id_v1: scene.id_v1,
+      name: scene.metadata.name,
+      group: { rid: scene.group.rid, rtype },
+      groupName: groupNameById.get(scene.group.rid)
+    };
+  }
+}
+
+export default SceneResource;

--- a/src/lib/hue-api/types.ts
+++ b/src/lib/hue-api/types.ts
@@ -379,6 +379,32 @@ export interface CombinedGroupResource {
   };
 }
 
+export interface SceneResource {
+  id: string;
+  type: "scene";
+  metadata: { name: string };
+  group: ResourceIdentifier;
+  status?: { active: "inactive" | "static" | "dynamic_palette" };
+}
+
+export interface SceneResourceResult {
+  errors: { description: string }[];
+  data: SceneResource[];
+}
+
+export type SceneRecallResponse = LightResourceResponse;
+
+/**
+ * Bare scene fields the driver cares about. Group display name is *not* resolved here —
+ * callers denormalise it from the integration's already-cached group config to avoid a
+ * room+zone fetch on every single-scene SSE event.
+ */
+export interface CombinedSceneResource {
+  id: string;
+  name: string;
+  group: { rid: string; rtype: "room" | "zone" };
+}
+
 export type GamutType = "A" | "B" | "C";
 
 /** CIE xy chromaticity coordinates for each primary of a light's color gamut triangle. */

--- a/src/lib/hue-api/types.ts
+++ b/src/lib/hue-api/types.ts
@@ -381,7 +381,6 @@ export interface CombinedGroupResource {
 
 export interface SceneResource {
   id: string;
-  id_v1?: string;
   type: "scene";
   metadata: { name: string };
   group: ResourceIdentifier;
@@ -408,7 +407,6 @@ export type SceneRecallResponse = LightResourceResponse;
  */
 export interface CombinedSceneResource {
   id: string;
-  id_v1?: string;
   name: string;
   group: { rid: string; rtype: "room" | "zone" };
   groupName: string | undefined;

--- a/src/lib/hue-api/types.ts
+++ b/src/lib/hue-api/types.ts
@@ -379,6 +379,41 @@ export interface CombinedGroupResource {
   };
 }
 
+export interface SceneResource {
+  id: string;
+  id_v1?: string;
+  type: "scene";
+  metadata: { name: string };
+  group: ResourceIdentifier;
+  status?: { active: "inactive" | "static" | "dynamic_palette" };
+}
+
+export interface SceneResourceResult {
+  errors: { description: string }[];
+  data: SceneResource[];
+}
+
+export type SceneRecallAction = "active" | "dynamic_palette" | "static";
+
+export interface SceneRecallBody {
+  recall: { action: SceneRecallAction };
+}
+
+export type SceneRecallResponse = LightResourceResponse;
+
+/**
+ * Hydrated scene record: the bare scene fields the driver cares about, plus the
+ * resolved display name of the scene's owning room/zone (denormalised at fetch
+ * time so the read path can render entity names without a cross-table lookup).
+ */
+export interface CombinedSceneResource {
+  id: string;
+  id_v1?: string;
+  name: string;
+  group: { rid: string; rtype: "room" | "zone" };
+  groupName: string | undefined;
+}
+
 export type GamutType = "A" | "B" | "C";
 
 /** CIE xy chromaticity coordinates for each primary of a light's color gamut triangle. */

--- a/src/lib/philips-hue.ts
+++ b/src/lib/philips-hue.ts
@@ -15,14 +15,20 @@ import {
   LightCommands,
   LightFeatures,
   LightStates,
+  Select,
+  SelectAttributes,
+  SelectCommands,
+  SelectStates,
   StatusCodes
 } from "@unfoldedcircle/integration-api";
-import Config, { ConfigEvent, GroupConfig, LightOrGroupConfig } from "../config.js";
+import Config, { ConfigEvent, GroupConfig, LightOrGroupConfig, SceneConfig } from "../config.js";
 import log from "../log.js";
 import {
   addAvailableGroups,
   addAvailableLights,
+  addAvailableScenes,
   brightnessToPercent,
+  buildSceneOptionsForGroup,
   colorTempToMirek,
   convertHSVtoXY,
   convertXYtoHSV,
@@ -33,12 +39,15 @@ import {
   getMinMaxMirek,
   getMostCommonGamut,
   mirekToColorTemp,
-  percentToBrightness
+  percentToBrightness,
+  SCENE_NONE_OPTION
 } from "../util.js";
 import HueApi, { HueError } from "./hue-api/api.js";
 import HueEventStream from "./hue-api/event-stream.js";
 import { CombinedGroupResource, HueEvent, LightResource, LightResourceParams } from "./hue-api/types.js";
 import PhilipsHueSetup from "./setup.js";
+
+const SCENE_SELECT_PREFIX = "hue_scenes_";
 
 const MIGRATION_MAX_RETRIES = 6;
 const MIGRATION_INITIAL_RETRY_DELAY_MS = 1000;
@@ -58,6 +67,13 @@ class PhilipsHue {
   private v1LightIds: Set<string> = new Set();
   // migration guard flag
   private migrating = false;
+  // Per-group scene Select state. Each group with scenes gets one Select entity named
+  // "<Group> scenes"; these maps translate between the option label shown to the user
+  // and the underlying Hue scene id. Forward map is keyed by groupId so we can wholesale
+  // rebuild a group's Select on scene add/remove/rename; reverse map is keyed by sceneId
+  // so SSE handlers (status.active transitions) can find the option in O(1).
+  private sceneOptionToId: Map<string, Map<string, string>> = new Map();
+  private sceneIdToOption: Map<string, { groupId: string; option: string }> = new Map();
 
   constructor() {
     this.uc = new IntegrationAPI();
@@ -121,6 +137,12 @@ class PhilipsHue {
             addAvailableGroups(zoneData, "zone", this.config);
           }
 
+          const scenes = await this.hueApi.sceneResource.getScenes();
+          this.config.removeScenes();
+          if (scenes.length > 0) {
+            addAvailableScenes(scenes, this.config);
+          }
+
           this.updateEntityIndexes();
           this.config.markMigrated();
           this.migrating = false;
@@ -172,6 +194,33 @@ class PhilipsHue {
         features: light.features
       });
       this.addAvailableLight(lightEntity);
+    }
+    this.rebuildAllSceneSelects();
+  }
+
+  /**
+   * (Re)build a Select entity for every group that has at least one configured scene.
+   *
+   * Groups without scenes get no entity (and any pre-existing Select is removed).
+   */
+  private rebuildAllSceneSelects() {
+    const scenesByGroup = new Map<string, (SceneConfig & { id: string })[]>();
+    for (const scene of this.config.getScenes()) {
+      const bucket = scenesByGroup.get(scene.groupId);
+      if (bucket) {
+        bucket.push(scene);
+      } else {
+        scenesByGroup.set(scene.groupId, [scene]);
+      }
+    }
+    // Remove Select entities for groups that no longer have scenes
+    for (const groupId of this.sceneOptionToId.keys()) {
+      if (!scenesByGroup.has(groupId)) {
+        this.removeSceneSelectForGroup(groupId);
+      }
+    }
+    for (const [groupId, scenes] of scenesByGroup) {
+      this.rebuildSceneSelectForGroup(groupId, scenes);
     }
   }
 
@@ -253,6 +302,8 @@ class PhilipsHue {
     // removing entities with a single bridge is easy
     this.uc.clearConfiguredEntities();
     this.uc.clearAvailableEntities();
+    this.sceneOptionToId.clear();
+    this.sceneIdToOption.clear();
   }
 
   // terri: check if you can simplify since
@@ -265,6 +316,8 @@ class PhilipsHue {
         features: event.data.features
       });
       this.addAvailableLight(light);
+    } else if (event.type === "scene-added") {
+      this.rebuildSceneSelectForGroup(event.data.groupId);
     }
     this.updateEntityIndexes();
   }
@@ -424,6 +477,236 @@ class PhilipsHue {
     }
   }
 
+  private getSceneSelectEntityId(groupId: string): string {
+    return `${SCENE_SELECT_PREFIX}${groupId}`;
+  }
+
+  private groupIdFromSelectEntityId(entityId: string): string | undefined {
+    if (!entityId.startsWith(SCENE_SELECT_PREFIX)) {
+      return undefined;
+    }
+    return entityId.slice(SCENE_SELECT_PREFIX.length);
+  }
+
+  /**
+   * Rebuild (create or update) the scene Select entity for the given group.
+   *
+   * If `scenes` is omitted, queries the config for scenes belonging to `groupId`. Removes
+   * the Select if the group ends up with zero scenes — a Select with only the placeholder
+   * option carries no information and would clutter the entity list.
+   */
+  private rebuildSceneSelectForGroup(groupId: string, scenes?: (SceneConfig & { id: string })[]) {
+    const groupScenes = scenes ?? this.config.getScenes().filter((s) => s.groupId === groupId);
+    if (groupScenes.length === 0) {
+      this.removeSceneSelectForGroup(groupId);
+      return;
+    }
+
+    const { optionToId, idToOption } = buildSceneOptionsForGroup(groupScenes);
+    this.sceneOptionToId.set(groupId, optionToId);
+    // Refresh the reverse-direction map: drop stale entries for this group, then re-add.
+    for (const [sceneId, mapping] of this.sceneIdToOption) {
+      if (mapping.groupId === groupId) {
+        this.sceneIdToOption.delete(sceneId);
+      }
+    }
+    for (const [sceneId, option] of idToOption) {
+      this.sceneIdToOption.set(sceneId, { groupId, option });
+    }
+
+    const currentOption = this.deriveCurrentOptionForGroup(groupId) ?? SCENE_NONE_OPTION;
+    const options = this.computeOptionsForGroup(groupId, currentOption !== SCENE_NONE_OPTION);
+
+    const groupName = groupScenes[0].groupName;
+    const entityId = this.getSceneSelectEntityId(groupId);
+    const name = groupName ? `${groupName} scenes` : "Hue scenes";
+    const available = this.uc.getAvailableEntities();
+
+    if (available.contains(entityId)) {
+      const configured = this.uc.getConfiguredEntities();
+      const updates: Record<string, string | string[] | SelectStates> = {
+        [SelectAttributes.Options]: options,
+        [SelectAttributes.CurrentOption]: currentOption
+      };
+      configured.updateEntityAttributes(entityId, updates);
+      available.updateEntityAttributes(entityId, updates);
+    } else {
+      const select = new Select(entityId, name, {
+        description: groupName ? `Hue scenes in ${groupName}` : "Hue scenes",
+        area: groupName,
+        attributes: {
+          [SelectAttributes.State]: SelectStates.On,
+          [SelectAttributes.Options]: options,
+          [SelectAttributes.CurrentOption]: currentOption
+        }
+      });
+      select.setCmdHandler(this.onSceneSelectCommand.bind(this));
+      available.addAvailableEntity(select);
+    }
+  }
+
+  /**
+   * Build the options array for a group's Select, inserting the `—` placeholder only when no
+   * scene is currently active. The placeholder represents the current state when it's shown,
+   * so it disappears from the dropdown the moment any scene becomes active.
+   */
+  private computeOptionsForGroup(groupId: string, sceneActive: boolean): string[] {
+    const optionToId = this.sceneOptionToId.get(groupId);
+    const sceneOptions = optionToId ? [...optionToId.keys()] : [];
+    return sceneActive ? sceneOptions : [SCENE_NONE_OPTION, ...sceneOptions];
+  }
+
+  private removeSceneSelectForGroup(groupId: string) {
+    this.sceneOptionToId.delete(groupId);
+    for (const [sceneId, mapping] of this.sceneIdToOption) {
+      if (mapping.groupId === groupId) {
+        this.sceneIdToOption.delete(sceneId);
+      }
+    }
+    const entityId = this.getSceneSelectEntityId(groupId);
+    this.uc.getConfiguredEntities().removeEntity(entityId);
+    this.uc.getAvailableEntities().removeEntity(entityId);
+  }
+
+  /**
+   * Find the option string that should currently be shown for a group's Select.
+   *
+   * Returns the active scene's option label if one is set on the group's existing Select,
+   * mapped through the (possibly just-rebuilt) options. Returns undefined if there's no
+   * Select yet for this group (caller decides what to seed).
+   */
+  private deriveCurrentOptionForGroup(groupId: string): string | undefined {
+    const entityId = this.getSceneSelectEntityId(groupId);
+    const existing = this.uc.getAvailableEntities().getEntity(entityId);
+    if (!existing) {
+      return undefined;
+    }
+    const prevOption = (existing.attributes?.[SelectAttributes.CurrentOption] as string | undefined) ?? undefined;
+    if (!prevOption || prevOption === SCENE_NONE_OPTION) {
+      return SCENE_NONE_OPTION;
+    }
+    // If the previously-active scene still exists in this group, remap its label (it may
+    // have been renamed). Otherwise, fall back to the placeholder.
+    const optionToId = this.sceneOptionToId.get(groupId);
+    const sceneId = optionToId?.get(prevOption);
+    if (sceneId) {
+      const mapping = this.sceneIdToOption.get(sceneId);
+      return mapping?.option ?? SCENE_NONE_OPTION;
+    }
+    return SCENE_NONE_OPTION;
+  }
+
+  /**
+   * Set the Select's state for a group, given either the scene id whose activation we just
+   * observed or undefined to revert to "no scene active".
+   *
+   * Broadcasts both `current_option` and `options` in the same entity_change so the Remote
+   * sees a consistent snapshot: when a scene is active, the placeholder is absent from
+   * `options`; when no scene is active, the placeholder is present and is the current option.
+   */
+  private setSelectCurrentOption(groupId: string, sceneId: string | undefined) {
+    const entityId = this.getSceneSelectEntityId(groupId);
+    if (!this.uc.getAvailableEntities().contains(entityId)) {
+      return;
+    }
+    const option = sceneId ? (this.sceneIdToOption.get(sceneId)?.option ?? SCENE_NONE_OPTION) : SCENE_NONE_OPTION;
+    const sceneActive = option !== SCENE_NONE_OPTION;
+    const updates = {
+      [SelectAttributes.CurrentOption]: option,
+      [SelectAttributes.Options]: this.computeOptionsForGroup(groupId, sceneActive)
+    };
+    this.uc.getConfiguredEntities().updateEntityAttributes(entityId, updates);
+    this.uc.getAvailableEntities().updateEntityAttributes(entityId, updates);
+  }
+
+  private async onSceneSelectCommand(
+    entity: Entity,
+    command: string,
+    params?: { [key: string]: string | number | boolean }
+  ): Promise<StatusCodes> {
+    const groupId = this.groupIdFromSelectEntityId(entity.id);
+    if (!groupId) {
+      log.error("onSceneSelectCommand: entity id %s is not a scene Select", entity.id);
+      return StatusCodes.BadRequest;
+    }
+    const optionToId = this.sceneOptionToId.get(groupId);
+    if (!optionToId) {
+      log.warn("onSceneSelectCommand: no options registered for group %s", groupId);
+      return StatusCodes.BadRequest;
+    }
+
+    let targetOption: string | undefined;
+    switch (command) {
+      case SelectCommands.SelectOption:
+        targetOption = typeof params?.option === "string" ? params.option : undefined;
+        break;
+      case SelectCommands.SelectFirst:
+      case SelectCommands.SelectLast:
+      case SelectCommands.SelectNext:
+      case SelectCommands.SelectPrevious: {
+        // Navigation uses whatever options the Remote currently sees — the entity's live
+        // `options` attribute, not a freshly-built list. With the dynamic placeholder, the
+        // visible options vary based on whether a scene is active.
+        const currentEntity = this.uc.getAvailableEntities().getEntity(entity.id);
+        const options = (currentEntity?.attributes?.[SelectAttributes.Options] as string[] | undefined) ?? [];
+        if (options.length <= 1) {
+          // Empty, or only the `—` placeholder — nothing to navigate.
+          return StatusCodes.Ok;
+        }
+        const currentOption =
+          (currentEntity?.attributes?.[SelectAttributes.CurrentOption] as string | undefined) ?? SCENE_NONE_OPTION;
+        const currentIdx = Math.max(0, options.indexOf(currentOption));
+        const cycle = params?.cycle !== false;
+        let nextIdx: number;
+        if (command === SelectCommands.SelectFirst) {
+          nextIdx = 0;
+        } else if (command === SelectCommands.SelectLast) {
+          nextIdx = options.length - 1;
+        } else if (command === SelectCommands.SelectNext) {
+          nextIdx = currentIdx + 1 >= options.length ? (cycle ? 0 : currentIdx) : currentIdx + 1;
+        } else {
+          nextIdx = currentIdx - 1 < 0 ? (cycle ? options.length - 1 : currentIdx) : currentIdx - 1;
+        }
+        targetOption = options[nextIdx];
+        break;
+      }
+      default:
+        log.error("onSceneSelectCommand: unsupported command: %s", command);
+        return StatusCodes.BadRequest;
+    }
+
+    if (targetOption === undefined) {
+      log.warn("onSceneSelectCommand: missing `option` parameter for select_option");
+      return StatusCodes.BadRequest;
+    }
+
+    if (targetOption === SCENE_NONE_OPTION) {
+      // Selecting the placeholder is a no-op — the Hue API has no "deactivate scene" verb.
+      // The Select stays where it is (the bridge will resolve current_option via SSE if anything
+      // actually changed).
+      return StatusCodes.Ok;
+    }
+
+    const sceneId = optionToId.get(targetOption);
+    if (!sceneId) {
+      log.warn("onSceneSelectCommand: option %s not recognized for group %s", targetOption, groupId);
+      return StatusCodes.BadRequest;
+    }
+
+    // Optimistic UI: paint the new option immediately so the remote doesn't sit in a "pending"
+    // state while the bridge processes. Recall is fire-and-forget; SSE will reaffirm on success
+    // and we revert on failure. The bridge's PUT /scene response can take >1.5s; awaiting it
+    // would block this handler (and the remote's UI) for the full RTT plus any retries.
+    this.setSelectCurrentOption(groupId, sceneId);
+    this.hueApi.sceneResource.recall(sceneId).catch((error) => {
+      log.error("Scene recall failed for %s, reverting Select to placeholder:", sceneId, error);
+      // We don't actually know which scene (if any) the bridge is currently in; safest is to
+      // revert to the placeholder. SSE will correct if some other scene was already active.
+      this.setSelectCurrentOption(groupId, undefined);
+    });
+    return StatusCodes.Ok;
+  }
+
   private getMirek(entityId: string, config?: LightOrGroupConfig) {
     const minMirek = config?.mirek_schema?.mirek_minimum;
     const maxMirek = config?.mirek_schema?.mirek_maximum;
@@ -514,9 +797,71 @@ class PhilipsHue {
           this.syncGroupState(data.id, updateGroupData).catch((error) =>
             log.error("Syncing group state failed for event stream update:", error)
           );
+          // a group rename cascades to the displayed names of any scenes pointing at it
+          this.propagateGroupRenameToScenes(data.id, updateGroupData.metadata.name);
+        }
+      } else if (data.type === "scene") {
+        log.debug("event stream scene update: %s", JSON.stringify(data));
+        const sceneCfg = this.config.getScene(data.id);
+        if (!sceneCfg) {
+          log.debug("No config for scene %s, skipping update", data.id);
+          continue;
+        }
+        let labelsChanged = false;
+        if (data.metadata && typeof data.metadata === "object" && "name" in data.metadata) {
+          const newName = data.metadata.name as string;
+          if (newName !== sceneCfg.name) {
+            this.config.updateScene(data.id, { ...sceneCfg, name: newName });
+            labelsChanged = true;
+          }
+        }
+        // Whichever scene the bridge reports as active is reflected in its group's Select.
+        // The bridge uses several active-state strings ("static", "dynamic_palette", …) for
+        // "scene is playing"; we only care about the binary "playing vs not".
+        if (data.status && typeof data.status === "object" && "active" in data.status) {
+          if (data.status.active !== "inactive") {
+            this.setSelectCurrentOption(sceneCfg.groupId, data.id);
+          } else {
+            // Only clear if this scene is the one currently shown — another scene becoming
+            // active will already have moved the Select away from this one.
+            const mapping = this.sceneIdToOption.get(data.id);
+            if (mapping) {
+              const entityId = this.getSceneSelectEntityId(mapping.groupId);
+              const existing = this.uc.getAvailableEntities().getEntity(entityId);
+              const currentOption = existing?.attributes?.[SelectAttributes.CurrentOption] as string | undefined;
+              if (currentOption === mapping.option) {
+                this.setSelectCurrentOption(mapping.groupId, undefined);
+              }
+            }
+          }
+        }
+        if (labelsChanged) {
+          // Option label for this scene changed — rebuild the group's Select so options
+          // (and the maps) stay in lockstep with the scene name shown to the user.
+          this.rebuildSceneSelectForGroup(sceneCfg.groupId);
         }
       }
     }
+  }
+
+  private propagateGroupRenameToScenes(groupId: string, newGroupName: string) {
+    let renamed = false;
+    for (const scene of this.config.getScenes()) {
+      if (scene.groupId === groupId && scene.groupName !== newGroupName) {
+        const { id, ...rest } = scene;
+        this.config.updateScene(id, { ...rest, groupName: newGroupName });
+        renamed = true;
+      }
+    }
+    if (!renamed) {
+      return;
+    }
+    // The Select entity name embeds the group name ("<Group> scenes") and uses it as the area;
+    // both need to be updated. The integration-api entity-list API doesn't support a name edit,
+    // so we drop and re-add the entity instead. Any subscribers see one entity-removed +
+    // entity-added pair, which is acceptable for the rare group-rename case.
+    this.removeSceneSelectForGroup(groupId);
+    this.rebuildSceneSelectForGroup(groupId);
   }
 
   private async handleEventStreamAdd(event: HueEvent) {
@@ -534,6 +879,14 @@ class PhilipsHue {
             addAvailableGroups([group], data.type, this.config);
           }
           break;
+        case "scene": {
+          const scene = await this.hueApi.sceneResource.getScene(data.id);
+          addAvailableScenes([scene], this.config);
+          this.rebuildSceneSelectForGroup(scene.group.rid);
+          // If the scene is recalled right after creation, the bridge will emit a separate
+          // status.active update — handled in handleEventStreamUpdate. Nothing to seed here.
+          break;
+        }
       }
     }
   }
@@ -541,6 +894,14 @@ class PhilipsHue {
   private handleEventStreamDelete(event: HueEvent) {
     const configured = this.uc.getConfiguredEntities();
     for (const data of event.data) {
+      if (data.type === "scene") {
+        const sceneCfg = this.config.getScene(data.id);
+        this.config.removeScene(data.id);
+        if (sceneCfg) {
+          this.rebuildSceneSelectForGroup(sceneCfg.groupId);
+        }
+        continue;
+      }
       const publicIds = this.getPublicEntityIds(data.id);
       for (const publicEntityId of publicIds) {
         configured.updateEntityAttributes(publicEntityId, {
@@ -577,6 +938,21 @@ class PhilipsHue {
     if (hubConfig && hubConfig.ip) {
       // manually fetch the current light states and send entity updates
       for (const id of ids) {
+        if (id.startsWith(SCENE_SELECT_PREFIX)) {
+          // Scene Select entities are not lights/groups, so no per-entity bridge fetch is
+          // needed. But: any attribute mutations that happened on availableEntities before
+          // this subscribe (e.g. during setup, when scenes were added one at a time and the
+          // Select's `options` list grew) were never broadcast — `updateEntityAttributes`
+          // only broadcasts when the entity is already in configuredEntities. The framework
+          // adds the entity to configured BEFORE emitting SubscribeEntities, so re-sending
+          // the current attributes here lets the Remote learn the full options array,
+          // current_option, and state in one entity_change event.
+          const entity = this.uc.getAvailableEntities().getEntity(id);
+          if (entity?.attributes) {
+            this.uc.getConfiguredEntities().updateEntityAttributes(id, { ...entity.attributes });
+          }
+          continue;
+        }
         await this.updateLight(id);
       }
       this.updateEntityIndexes();
@@ -628,10 +1004,39 @@ class PhilipsHue {
     // TODO get all lights at once instead of one call per light? Probably have to split by group type
     for (const entity of this.uc.getConfiguredEntities().getEntities()) {
       const entityId = entity.entity_id as string;
+      // Scene Select entities don't have a light/group config; their state is refreshed by
+      // refreshSceneSelectStates() below from the scene resource itself.
+      if (entityId.startsWith(SCENE_SELECT_PREFIX)) {
+        continue;
+      }
       await this.updateLight(entityId);
     }
     this.updateEntityIndexes();
+    await this.refreshSceneSelectStates();
     // TODO if an error occurred while updating lights: perform a manual connectivity test and set entity states
+  }
+
+  /**
+   * Apply the bridge's current per-group active scene to each Select's `current_option`.
+   * Called on event-stream connect so the UI is correct without waiting for the next SSE
+   * transition.
+   */
+  private async refreshSceneSelectStates() {
+    if (this.sceneOptionToId.size === 0) {
+      return;
+    }
+    try {
+      const activeScenes = await this.hueApi.sceneResource.getActiveScenes();
+      const activeByGroup = new Map<string, string>();
+      for (const scene of activeScenes) {
+        activeByGroup.set(scene.groupId, scene.id);
+      }
+      for (const groupId of this.sceneOptionToId.keys()) {
+        this.setSelectCurrentOption(groupId, activeByGroup.get(groupId));
+      }
+    } catch (error) {
+      log.error("Refreshing scene Select states failed:", error);
+    }
   }
 
   /**

--- a/src/lib/philips-hue.ts
+++ b/src/lib/philips-hue.ts
@@ -667,6 +667,7 @@ class PhilipsHue {
           this.propagateGroupRenameToScenes(data.id, updateGroupData.metadata.name);
         }
       } else if (data.type === "scene") {
+        log.debug("event stream scene update: %s", JSON.stringify(data));
         const sceneCfg = this.config.getScene(data.id);
         if (!sceneCfg) {
           log.debug("No config for scene %s, skipping update", data.id);

--- a/src/lib/philips-hue.ts
+++ b/src/lib/philips-hue.ts
@@ -6,6 +6,9 @@
  */
 
 import {
+  Button,
+  ButtonCommands,
+  ButtonStates,
   DeviceStates,
   Entity,
   Events,
@@ -15,13 +18,19 @@ import {
   LightCommands,
   LightFeatures,
   LightStates,
-  StatusCodes
+  StatusCodes,
+  Switch,
+  SwitchAttributes,
+  SwitchCommands,
+  SwitchFeatures,
+  SwitchStates
 } from "@unfoldedcircle/integration-api";
-import Config, { ConfigEvent, GroupConfig, LightOrGroupConfig } from "../config.js";
+import Config, { ConfigEvent, GroupConfig, LightOrGroupConfig, SceneConfig } from "../config.js";
 import log from "../log.js";
 import {
   addAvailableGroups,
   addAvailableLights,
+  addAvailableScenes,
   brightnessToPercent,
   colorTempToMirek,
   convertHSVtoXY,
@@ -37,8 +46,17 @@ import {
 } from "../util.js";
 import HueApi, { HueError } from "./hue-api/api.js";
 import HueEventStream from "./hue-api/event-stream.js";
-import { CombinedGroupResource, HueEvent, LightResource, LightResourceParams } from "./hue-api/types.js";
+import {
+  CombinedGroupResource,
+  HueEvent,
+  LightResource,
+  LightResourceParams,
+  SceneRecallAction
+} from "./hue-api/types.js";
 import PhilipsHueSetup from "./setup.js";
+
+const SCENE_ENTITY_PREFIX = "hue_scene_";
+const SCENE_DYNAMIC_TOGGLE_ID = "hue_scenes_dynamic_toggle";
 
 const MIGRATION_MAX_RETRIES = 6;
 const MIGRATION_INITIAL_RETRY_DELAY_MS = 1000;
@@ -58,6 +76,11 @@ class PhilipsHue {
   private v1LightIds: Set<string> = new Set();
   // migration guard flag
   private migrating = false;
+  // Most recently activated scene id. The dynamic-toggle Switch acts on this scene
+  // and is updated from SSE `scene.status.active` transitions (so it follows scene
+  // activations from the Hue app and other clients, not just the remote).
+  private lastActivatedSceneId?: string;
+  private dynamicToggleState: SwitchStates = SwitchStates.Off;
 
   constructor() {
     this.uc = new IntegrationAPI();
@@ -121,6 +144,12 @@ class PhilipsHue {
             addAvailableGroups(zoneData, "zone", this.config);
           }
 
+          const scenes = await this.hueApi.sceneResource.getScenes();
+          this.config.removeScenes();
+          if (scenes.length > 0) {
+            addAvailableScenes(scenes, this.config);
+          }
+
           this.updateEntityIndexes();
           this.config.markMigrated();
           this.migrating = false;
@@ -172,6 +201,13 @@ class PhilipsHue {
         features: light.features
       });
       this.addAvailableLight(lightEntity);
+    }
+    const scenes = this.config.getScenes();
+    for (const scene of scenes) {
+      this.addAvailableScene(scene);
+    }
+    if (scenes.length > 0) {
+      this.addAvailableDynamicToggle();
     }
   }
 
@@ -253,6 +289,8 @@ class PhilipsHue {
     // removing entities with a single bridge is easy
     this.uc.clearConfiguredEntities();
     this.uc.clearAvailableEntities();
+    this.lastActivatedSceneId = undefined;
+    this.dynamicToggleState = SwitchStates.Off;
   }
 
   // terri: check if you can simplify since
@@ -265,6 +303,9 @@ class PhilipsHue {
         features: event.data.features
       });
       this.addAvailableLight(light);
+    } else if (event.type === "scene-added") {
+      this.addAvailableScene(event.data);
+      this.addAvailableDynamicToggle();
     }
     this.updateEntityIndexes();
   }
@@ -424,6 +465,114 @@ class PhilipsHue {
     }
   }
 
+  private getSceneEntityId(sceneId: string): string {
+    return `${SCENE_ENTITY_PREFIX}${sceneId}`;
+  }
+
+  private formatSceneName(scene: SceneConfig): string {
+    return scene.groupName ? `${scene.groupName} - ${scene.name}` : scene.name;
+  }
+
+  private addAvailableScene(scene: SceneConfig & { id: string }) {
+    const entityId = this.getSceneEntityId(scene.id);
+    const button = new Button(entityId, this.formatSceneName(scene), {
+      description: scene.groupName ? `Hue scene in ${scene.groupName}` : "Hue scene",
+      area: scene.groupName,
+      state: ButtonStates.Available
+    });
+    button.setCmdHandler(this.onSceneCommand.bind(this));
+    this.uc.addAvailableEntity(button);
+  }
+
+  private async onSceneCommand(
+    entity: Entity,
+    command: string,
+    _params?: { [key: string]: string | number | boolean }
+  ): Promise<StatusCodes> {
+    if (command !== ButtonCommands.Push) {
+      log.error("onSceneCommand: unsupported command: %s", command);
+      return StatusCodes.BadRequest;
+    }
+    const entityId = entity.id as string;
+    const sceneId = entityId.startsWith(SCENE_ENTITY_PREFIX) ? entityId.slice(SCENE_ENTITY_PREFIX.length) : entityId;
+    try {
+      await this.hueApi.sceneResource.recall(sceneId);
+      // Optimistic tracker update so a fast switch press lands on the right scene
+      // before SSE confirms.
+      this.lastActivatedSceneId = sceneId;
+      return StatusCodes.Ok;
+    } catch (error) {
+      if (error instanceof HueError) {
+        return error.statusCode;
+      }
+      log.error("Scene recall failed for %s", sceneId, error);
+      return StatusCodes.ServerError;
+    }
+  }
+
+  private addAvailableDynamicToggle() {
+    if (this.uc.getAvailableEntities().contains(SCENE_DYNAMIC_TOGGLE_ID)) {
+      return;
+    }
+    const toggle = new Switch(SCENE_DYNAMIC_TOGGLE_ID, "Hue Scene Dynamics", {
+      description: "ON starts the active scene's dynamic palette; OFF stops it.",
+      features: [SwitchFeatures.OnOff, SwitchFeatures.Toggle],
+      attributes: { [SwitchAttributes.State]: this.dynamicToggleState }
+    });
+    toggle.setCmdHandler(this.onDynamicToggleCommand.bind(this));
+    this.uc.addAvailableEntity(toggle);
+  }
+
+  private async onDynamicToggleCommand(
+    _entity: Entity,
+    command: string,
+    _params?: { [key: string]: string | number | boolean }
+  ): Promise<StatusCodes> {
+    if (!this.lastActivatedSceneId) {
+      log.warn("Dynamic toggle pressed but no scene has been activated yet; press a scene button first");
+      return StatusCodes.BadRequest;
+    }
+
+    let nextState: SwitchStates;
+    switch (command) {
+      case SwitchCommands.On:
+        nextState = SwitchStates.On;
+        break;
+      case SwitchCommands.Off:
+        nextState = SwitchStates.Off;
+        break;
+      case SwitchCommands.Toggle:
+        nextState = this.dynamicToggleState === SwitchStates.On ? SwitchStates.Off : SwitchStates.On;
+        break;
+      default:
+        log.error("onDynamicToggleCommand: unsupported command: %s", command);
+        return StatusCodes.BadRequest;
+    }
+
+    const action: SceneRecallAction = nextState === SwitchStates.On ? "dynamic_palette" : "static";
+    try {
+      await this.hueApi.sceneResource.recall(this.lastActivatedSceneId, action);
+      this.setDynamicToggleState(nextState);
+      return StatusCodes.Ok;
+    } catch (error) {
+      if (error instanceof HueError) {
+        return error.statusCode;
+      }
+      log.error("Dynamic toggle recall failed for scene %s", this.lastActivatedSceneId, error);
+      return StatusCodes.ServerError;
+    }
+  }
+
+  private setDynamicToggleState(state: SwitchStates) {
+    if (this.dynamicToggleState === state) {
+      return;
+    }
+    this.dynamicToggleState = state;
+    this.uc.getConfiguredEntities().updateEntityAttributes(SCENE_DYNAMIC_TOGGLE_ID, {
+      [SwitchAttributes.State]: state
+    });
+  }
+
   private getMirek(entityId: string, config?: LightOrGroupConfig) {
     const minMirek = config?.mirek_schema?.mirek_minimum;
     const maxMirek = config?.mirek_schema?.mirek_maximum;
@@ -514,7 +663,41 @@ class PhilipsHue {
           this.syncGroupState(data.id, updateGroupData).catch((error) =>
             log.error("Syncing group state failed for event stream update:", error)
           );
+          // a group rename cascades to the displayed names of any scenes pointing at it
+          this.propagateGroupRenameToScenes(data.id, updateGroupData.metadata.name);
         }
+      } else if (data.type === "scene") {
+        const sceneCfg = this.config.getScene(data.id);
+        if (!sceneCfg) {
+          log.debug("No config for scene %s, skipping update", data.id);
+          continue;
+        }
+        if (data.metadata && typeof data.metadata === "object" && "name" in data.metadata) {
+          const newName = data.metadata.name as string;
+          if (newName !== sceneCfg.name) {
+            this.config.updateScene(data.id, { ...sceneCfg, name: newName });
+          }
+        }
+        // Whichever scene the bridge reports as active becomes the toggle's target.
+        if (data.status && typeof data.status === "object" && "active" in data.status) {
+          const active = data.status.active as string;
+          if (active === "dynamic_palette" || active === "static") {
+            this.lastActivatedSceneId = data.id;
+            this.setDynamicToggleState(active === "dynamic_palette" ? SwitchStates.On : SwitchStates.Off);
+          } else if (active === "inactive" && this.lastActivatedSceneId === data.id) {
+            this.lastActivatedSceneId = undefined;
+            this.setDynamicToggleState(SwitchStates.Off);
+          }
+        }
+      }
+    }
+  }
+
+  private propagateGroupRenameToScenes(groupId: string, newGroupName: string) {
+    for (const scene of this.config.getScenes()) {
+      if (scene.groupId === groupId && scene.groupName !== newGroupName) {
+        const { id, ...rest } = scene;
+        this.config.updateScene(id, { ...rest, groupName: newGroupName });
       }
     }
   }
@@ -534,13 +717,30 @@ class PhilipsHue {
             addAvailableGroups([group], data.type, this.config);
           }
           break;
+        case "scene": {
+          const scene = await this.hueApi.sceneResource.getScene(data.id);
+          addAvailableScenes([scene], this.config);
+          break;
+        }
       }
     }
   }
 
   private handleEventStreamDelete(event: HueEvent) {
     const configured = this.uc.getConfiguredEntities();
+    const available = this.uc.getAvailableEntities();
     for (const data of event.data) {
+      if (data.type === "scene") {
+        const entityId = this.getSceneEntityId(data.id);
+        configured.removeEntity(entityId);
+        available.removeEntity(entityId);
+        this.config.removeScene(data.id);
+        if (this.lastActivatedSceneId === data.id) {
+          this.lastActivatedSceneId = undefined;
+          this.setDynamicToggleState(SwitchStates.Off);
+        }
+        continue;
+      }
       const publicIds = this.getPublicEntityIds(data.id);
       for (const publicEntityId of publicIds) {
         configured.updateEntityAttributes(publicEntityId, {
@@ -577,6 +777,10 @@ class PhilipsHue {
     if (hubConfig && hubConfig.ip) {
       // manually fetch the current light states and send entity updates
       for (const id of ids) {
+        // Scene buttons and the dynamic-toggle Switch are not lights/groups; skip the per-entity fetch.
+        if (id.startsWith(SCENE_ENTITY_PREFIX) || id === SCENE_DYNAMIC_TOGGLE_ID) {
+          continue;
+        }
         await this.updateLight(id);
       }
       this.updateEntityIndexes();

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -20,8 +20,9 @@ import { Bonjour } from "bonjour-service";
 import Config from "../config.js";
 import log from "../log.js";
 import {
-  addAvailableLights,
   addAvailableGroups,
+  addAvailableLights,
+  addAvailableScenes,
   convertImageToBase64,
   delay,
   getHubUrl,
@@ -313,6 +314,13 @@ class PhilipsHueSetup {
         const zoneData = await api.groupResource.getGroupResources("zone");
         if (zoneData.length > 0) {
           addAvailableGroups(zoneData, "zone", this.config);
+        }
+
+        // Scenes must come after groups: addAvailableScenes denormalises groupName from
+        // the already-cached group config (see util.ts:addAvailableScenes).
+        const sceneData = await api.sceneResource.getScenes();
+        if (sceneData.length > 0) {
+          addAvailableScenes(sceneData, this.config);
         }
 
         return new SetupComplete();

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,10 +7,27 @@
 
 import { LightFeatures } from "@unfoldedcircle/integration-api";
 import fs from "fs";
-import { CombinedGroupResource, GamutTriangle, GamutType, GroupType, LightResource } from "./lib/hue-api/types.js";
+import {
+  CombinedGroupResource,
+  CombinedSceneResource,
+  GamutTriangle,
+  GamutType,
+  GroupType,
+  LightResource
+} from "./lib/hue-api/types.js";
 import i18n from "i18n";
 import log from "./log.js";
-import Config, { GroupConfig, LightConfig } from "./config.js";
+import Config, { GroupConfig, LightConfig, SceneConfig } from "./config.js";
+
+/**
+ * Placeholder option shown when no scene is active in a group.
+ *
+ * The Select entity contract requires `current_option` to be one of the strings in
+ * `options`, so we always include this marker at the top of every per-group scene
+ * Select. Selecting it is a no-op (no bridge call) — it only ever appears as the
+ * UI state when the bridge reports no scene active for the group.
+ */
+export const SCENE_NONE_OPTION = "—";
 
 export function convertImageToBase64(file: string) {
   let data;
@@ -63,6 +80,61 @@ export function addAvailableGroups(groups: CombinedGroupResource[], groupType: G
       mirek_schema: getMinMaxMirek(group)
     } as GroupConfig);
   });
+}
+
+export function addAvailableScenes(scenes: CombinedSceneResource[], config: Config) {
+  scenes.forEach((scene) => {
+    if (config.getScene(scene.id)) {
+      log.info("Scene with id %s already exists in config, skipping", scene.id);
+      return;
+    }
+    // Resolve the owning group's display name from already-cached config — saves a room+zone
+    // fetch on every scene event. Orphan scenes (group deleted) get undefined, same as before.
+    config.addScene(scene.id, {
+      name: scene.name,
+      groupId: scene.group.rid,
+      groupRtype: scene.group.rtype,
+      groupName: config.getLight(scene.group.rid)?.name
+    });
+  });
+}
+
+/**
+ * Build the option labels and lookup maps for a single group's scene Select entity.
+ *
+ * The returned `options` array holds the group's scenes sorted alphabetically by name
+ * (case-insensitive). Scenes with duplicate names get ` (2)`, ` (3)` suffixes — Hue allows
+ * duplicate scene names within a group, but `current_option` is a string and must be unique
+ * to disambiguate, so we deterministically suffix in iteration order.
+ *
+ * This helper deliberately does **not** include {@link SCENE_NONE_OPTION}. The "no scene
+ * active" placeholder is inserted by the caller only when it actually represents current
+ * state — so it disappears from the dropdown whenever a real scene is active.
+ *
+ * Returns both directions of the option ↔ scene-id mapping so the SSE handlers (sceneId →
+ * option) and the command handler (option → sceneId) can each do their lookup in O(1).
+ */
+export function buildSceneOptionsForGroup(scenes: (SceneConfig & { id: string })[]): {
+  options: string[];
+  optionToId: Map<string, string>;
+  idToOption: Map<string, string>;
+} {
+  const optionToId = new Map<string, string>();
+  const idToOption = new Map<string, string>();
+  const options: string[] = [];
+
+  const sorted = [...scenes].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+  const seen = new Map<string, number>();
+  for (const scene of sorted) {
+    const base = scene.name;
+    const count = (seen.get(base) ?? 0) + 1;
+    seen.set(base, count);
+    const label = count === 1 ? base : `${base} (${count})`;
+    options.push(label);
+    optionToId.set(label, scene.id);
+    idToOption.set(scene.id, label);
+  }
+  return { options, optionToId, idToOption };
 }
 
 export function getLightFeatures(light: LightResource): LightFeatures[] {

--- a/src/util.ts
+++ b/src/util.ts
@@ -79,7 +79,6 @@ export function addAvailableScenes(scenes: CombinedSceneResource[], config: Conf
       return;
     }
     config.addScene(scene.id, {
-      id_v1: scene.id_v1,
       name: scene.name,
       groupId: scene.group.rid,
       groupRtype: scene.group.rtype,

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,7 +7,14 @@
 
 import { LightFeatures } from "@unfoldedcircle/integration-api";
 import fs from "fs";
-import { CombinedGroupResource, GamutTriangle, GamutType, GroupType, LightResource } from "./lib/hue-api/types.js";
+import {
+  CombinedGroupResource,
+  CombinedSceneResource,
+  GamutTriangle,
+  GamutType,
+  GroupType,
+  LightResource
+} from "./lib/hue-api/types.js";
 import i18n from "i18n";
 import log from "./log.js";
 import Config, { GroupConfig, LightConfig } from "./config.js";
@@ -62,6 +69,22 @@ export function addAvailableGroups(groups: CombinedGroupResource[], groupType: G
       gamut: getRepresentativeGamutTriangle(group),
       mirek_schema: getMinMaxMirek(group)
     } as GroupConfig);
+  });
+}
+
+export function addAvailableScenes(scenes: CombinedSceneResource[], config: Config) {
+  scenes.forEach((scene) => {
+    if (config.getScene(scene.id)) {
+      log.info("Scene with id %s already exists in config, skipping", scene.id);
+      return;
+    }
+    config.addScene(scene.id, {
+      id_v1: scene.id_v1,
+      name: scene.name,
+      groupId: scene.group.rid,
+      groupRtype: scene.group.rtype,
+      groupName: scene.groupName
+    });
   });
 }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,5 @@
 import test, { ExecutionContext, TestFn } from "ava";
-import Config, { LightOrGroupConfig } from "../src/config.js";
+import Config, { LightOrGroupConfig, SceneConfig } from "../src/config.js";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -139,3 +139,84 @@ configTest(
     }
   }
 );
+
+configTest("addScene then getScenes round-trips all SceneConfig fields", (t: ExecutionContext<TestContext>) => {
+  const config = new Config(t.context.tmpDir);
+  const sceneId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  const scene: SceneConfig = {
+    name: "Sunset",
+    groupId: "11111111-1111-1111-1111-111111111111",
+    groupRtype: "room",
+    groupName: "Living Room"
+  };
+
+  config.addScene(sceneId, scene);
+
+  t.deepEqual(config.getScene(sceneId), scene);
+
+  const all = config.getScenes();
+  t.is(all.length, 1);
+  t.deepEqual(all[0], { id: sceneId, ...scene });
+});
+
+configTest("updateScene short-circuits when content is identical", (t: ExecutionContext<TestContext>) => {
+  const config = new Config(t.context.tmpDir);
+  const sceneId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  const scene: SceneConfig = {
+    name: "Sunset",
+    groupId: "11111111-1111-1111-1111-111111111111",
+    groupRtype: "room",
+    groupName: "Living Room"
+  };
+
+  config.addScene(sceneId, scene);
+
+  const originalWriteFileSync = fs.writeFileSync;
+  let writeCount = 0;
+  fs.writeFileSync = (
+    p: string | number | URL | Buffer,
+    data: string | NodeJS.ArrayBufferView,
+    options?: fs.WriteFileOptions
+  ) => {
+    if (typeof p === "string" && p.includes("philips_hue_config.json")) {
+      writeCount++;
+    }
+    return originalWriteFileSync(p, data, options);
+  };
+
+  try {
+    config.updateScene(sceneId, { ...scene });
+    t.is(writeCount, 0, "Should not write when SceneConfig is unchanged");
+
+    config.updateScene(sceneId, { ...scene, name: "Sunset Glow" });
+    t.is(writeCount, 1, "Should write when scene name changes");
+
+    writeCount = 0;
+    config.updateScene(sceneId, { ...scene, name: "Sunset Glow", groupName: "Den" });
+    t.is(writeCount, 1, "Should write when groupName changes");
+  } finally {
+    fs.writeFileSync = originalWriteFileSync;
+  }
+});
+
+configTest("removeScene removes the entry; removeScenes wipes the map", (t: ExecutionContext<TestContext>) => {
+  const config = new Config(t.context.tmpDir);
+  const a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  const b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  const base: Omit<SceneConfig, "name"> = {
+    groupId: "11111111-1111-1111-1111-111111111111",
+    groupRtype: "room",
+    groupName: "Living Room"
+  };
+
+  config.addScene(a, { name: "Sunset", ...base });
+  config.addScene(b, { name: "Movie", ...base });
+  t.is(config.getScenes().length, 2);
+
+  config.removeScene(a);
+  t.is(config.getScene(a), undefined);
+  t.is(config.getScenes().length, 1);
+
+  config.removeScenes();
+  t.deepEqual(config.getScenes(), []);
+});

--- a/test/scene-resource.test.ts
+++ b/test/scene-resource.test.ts
@@ -1,0 +1,170 @@
+import test from "ava";
+import { HueError, ResourceApi } from "../src/lib/hue-api/api.js";
+import SceneResource from "../src/lib/hue-api/scene-resource.js";
+import { SceneRecallResponse, SceneResourceResult } from "../src/lib/hue-api/types.js";
+
+interface RequestRecord {
+  method: "GET" | "POST" | "PUT";
+  endpoint: string;
+  body?: unknown;
+}
+
+interface MockResponses {
+  [endpoint: string]: unknown;
+}
+
+function makeMockApi(responses: MockResponses): { api: ResourceApi; calls: RequestRecord[] } {
+  const calls: RequestRecord[] = [];
+  const api: ResourceApi = {
+    sendRequest: async <T>(method: "GET" | "POST" | "PUT", endpoint: string, body?: unknown): Promise<T> => {
+      calls.push({ method, endpoint, body });
+      if (!(endpoint in responses)) {
+        throw new Error(`mock api: no response configured for ${method} ${endpoint}`);
+      }
+      return responses[endpoint] as T;
+    }
+  };
+  return { api, calls };
+}
+
+const ROOM_ID = "11111111-1111-1111-1111-111111111111";
+const ZONE_ID = "22222222-2222-2222-2222-222222222222";
+const SCENE_IN_ROOM_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const SCENE_IN_ZONE_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const ORPHAN_SCENE_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+test("getScenes returns scene records with only one API call (no room/zone fetch)", async (t) => {
+  const scenesResponse: SceneResourceResult = {
+    errors: [],
+    data: [
+      {
+        id: SCENE_IN_ROOM_ID,
+        type: "scene",
+        metadata: { name: "Sunset" },
+        group: { rid: ROOM_ID, rtype: "room" }
+      },
+      {
+        id: SCENE_IN_ZONE_ID,
+        type: "scene",
+        metadata: { name: "Movie" },
+        group: { rid: ZONE_ID, rtype: "zone" }
+      }
+    ]
+  };
+
+  const { api, calls } = makeMockApi({
+    "/clip/v2/resource/scene": scenesResponse
+  });
+
+  const sceneResource = new SceneResource(api);
+  const scenes = await sceneResource.getScenes();
+
+  t.is(calls.length, 1, "should make exactly one API call (no room/zone fetch)");
+  t.is(calls[0].endpoint, "/clip/v2/resource/scene");
+  t.is(scenes.length, 2);
+
+  const room = scenes.find((s) => s.id === SCENE_IN_ROOM_ID);
+  t.truthy(room);
+  t.is(room?.name, "Sunset");
+  t.is(room?.group.rid, ROOM_ID);
+  t.is(room?.group.rtype, "room");
+
+  const zone = scenes.find((s) => s.id === SCENE_IN_ZONE_ID);
+  t.is(zone?.name, "Movie");
+  t.is(zone?.group.rid, ZONE_ID);
+  t.is(zone?.group.rtype, "zone");
+});
+
+test("getScenes returns empty array when no scenes exist", async (t) => {
+  const { api, calls } = makeMockApi({
+    "/clip/v2/resource/scene": { errors: [], data: [] } as SceneResourceResult
+  });
+
+  const sceneResource = new SceneResource(api);
+  const scenes = await sceneResource.getScenes();
+
+  t.deepEqual(scenes, []);
+  // when there are no scenes, we skip the room/zone fetch entirely
+  t.is(calls.length, 1);
+  t.is(calls[0].endpoint, "/clip/v2/resource/scene");
+});
+
+test("getScene maps empty data to NotFound HueError", async (t) => {
+  const { api } = makeMockApi({
+    [`/clip/v2/resource/scene/${ORPHAN_SCENE_ID}`]: { errors: [], data: [] } as SceneResourceResult
+  });
+
+  const sceneResource = new SceneResource(api);
+
+  await t.throwsAsync(() => sceneResource.getScene(ORPHAN_SCENE_ID), {
+    instanceOf: HueError,
+    message: "Scene resource not found"
+  });
+});
+
+test("recall PUTs to the scene endpoint with action: 'active'", async (t) => {
+  const recallResponse: SceneRecallResponse = {
+    errors: [],
+    data: [{ rid: SCENE_IN_ROOM_ID }]
+  };
+
+  const { api, calls } = makeMockApi({
+    [`/clip/v2/resource/scene/${SCENE_IN_ROOM_ID}`]: recallResponse
+  });
+
+  const sceneResource = new SceneResource(api);
+  const data = await sceneResource.recall(SCENE_IN_ROOM_ID);
+
+  t.is(calls.length, 1);
+  t.is(calls[0].method, "PUT");
+  t.is(calls[0].endpoint, `/clip/v2/resource/scene/${SCENE_IN_ROOM_ID}`);
+  t.deepEqual(calls[0].body, { recall: { action: "active" } });
+  t.deepEqual(data, [{ rid: SCENE_IN_ROOM_ID }]);
+});
+
+test("getActiveScenes returns the playing scenes and skips the room/zone fetch", async (t) => {
+  const scenesResponse: SceneResourceResult = {
+    errors: [],
+    data: [
+      {
+        id: SCENE_IN_ROOM_ID,
+        type: "scene",
+        metadata: { name: "Sunset" },
+        group: { rid: ROOM_ID, rtype: "room" },
+        status: { active: "static" }
+      },
+      {
+        id: SCENE_IN_ZONE_ID,
+        type: "scene",
+        metadata: { name: "Movie" },
+        group: { rid: ZONE_ID, rtype: "zone" },
+        status: { active: "inactive" }
+      },
+      {
+        id: ORPHAN_SCENE_ID,
+        type: "scene",
+        metadata: { name: "Stale" },
+        group: { rid: ROOM_ID, rtype: "room" }
+      }
+    ]
+  };
+
+  const { api, calls } = makeMockApi({
+    "/clip/v2/resource/scene": scenesResponse
+  });
+
+  const sceneResource = new SceneResource(api);
+  const active = await sceneResource.getActiveScenes();
+
+  t.is(calls.length, 1, "should make exactly one API call (no room/zone fetch)");
+  t.is(calls[0].endpoint, "/clip/v2/resource/scene");
+  t.deepEqual(active, [{ id: SCENE_IN_ROOM_ID, groupId: ROOM_ID }]);
+});
+
+test("getActiveScenes returns empty array when no scenes exist", async (t) => {
+  const { api } = makeMockApi({
+    "/clip/v2/resource/scene": { errors: [], data: [] } as SceneResourceResult
+  });
+  const sceneResource = new SceneResource(api);
+  t.deepEqual(await sceneResource.getActiveScenes(), []);
+});

--- a/test/scene-resource.test.ts
+++ b/test/scene-resource.test.ts
@@ -1,0 +1,173 @@
+import test from "ava";
+import { HueError, ResourceApi } from "../src/lib/hue-api/api.js";
+import SceneResource from "../src/lib/hue-api/scene-resource.js";
+import { GroupResourceResponse, SceneRecallResponse, SceneResourceResult } from "../src/lib/hue-api/types.js";
+
+interface RequestRecord {
+  method: "GET" | "POST" | "PUT";
+  endpoint: string;
+  body?: unknown;
+}
+
+interface MockResponses {
+  [endpoint: string]: unknown;
+}
+
+function makeMockApi(responses: MockResponses): { api: ResourceApi; calls: RequestRecord[] } {
+  const calls: RequestRecord[] = [];
+  const api: ResourceApi = {
+    sendRequest: async <T>(method: "GET" | "POST" | "PUT", endpoint: string, body?: unknown): Promise<T> => {
+      calls.push({ method, endpoint, body });
+      if (!(endpoint in responses)) {
+        throw new Error(`mock api: no response configured for ${method} ${endpoint}`);
+      }
+      return responses[endpoint] as T;
+    }
+  };
+  return { api, calls };
+}
+
+const ROOM_ID = "11111111-1111-1111-1111-111111111111";
+const ZONE_ID = "22222222-2222-2222-2222-222222222222";
+const SCENE_IN_ROOM_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const SCENE_IN_ZONE_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const ORPHAN_SCENE_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+const roomsResponse: GroupResourceResponse = {
+  errors: [],
+  data: [
+    {
+      id: ROOM_ID,
+      children: [],
+      services: [],
+      type: "room",
+      metadata: { name: "Living Room", archetype: "living_room" }
+    }
+  ]
+};
+
+const zonesResponse: GroupResourceResponse = {
+  errors: [],
+  data: [
+    {
+      id: ZONE_ID,
+      children: [],
+      services: [],
+      type: "zone",
+      metadata: { name: "Downstairs", archetype: "other" }
+    }
+  ]
+};
+
+test("getScenes resolves groupName for room and zone scenes, leaves orphans undefined", async (t) => {
+  const scenesResponse: SceneResourceResult = {
+    errors: [],
+    data: [
+      {
+        id: SCENE_IN_ROOM_ID,
+        type: "scene",
+        metadata: { name: "Sunset" },
+        group: { rid: ROOM_ID, rtype: "room" }
+      },
+      {
+        id: SCENE_IN_ZONE_ID,
+        type: "scene",
+        metadata: { name: "Movie" },
+        group: { rid: ZONE_ID, rtype: "zone" }
+      },
+      {
+        id: ORPHAN_SCENE_ID,
+        type: "scene",
+        metadata: { name: "Stale" },
+        group: { rid: "deadbeef-dead-beef-dead-beefdeadbeef", rtype: "room" }
+      }
+    ]
+  };
+
+  const { api } = makeMockApi({
+    "/clip/v2/resource/scene": scenesResponse,
+    "/clip/v2/resource/room": roomsResponse,
+    "/clip/v2/resource/zone": zonesResponse
+  });
+
+  const sceneResource = new SceneResource(api);
+  const scenes = await sceneResource.getScenes();
+
+  t.is(scenes.length, 3);
+
+  const room = scenes.find((s) => s.id === SCENE_IN_ROOM_ID);
+  t.truthy(room);
+  t.is(room?.name, "Sunset");
+  t.is(room?.group.rid, ROOM_ID);
+  t.is(room?.group.rtype, "room");
+  t.is(room?.groupName, "Living Room");
+
+  const zone = scenes.find((s) => s.id === SCENE_IN_ZONE_ID);
+  t.is(zone?.groupName, "Downstairs");
+  t.is(zone?.group.rtype, "zone");
+
+  const orphan = scenes.find((s) => s.id === ORPHAN_SCENE_ID);
+  t.is(orphan?.groupName, undefined, "orphan scene resolves groupName to undefined without throwing");
+});
+
+test("getScenes returns empty array when no scenes exist", async (t) => {
+  const { api, calls } = makeMockApi({
+    "/clip/v2/resource/scene": { errors: [], data: [] } as SceneResourceResult
+  });
+
+  const sceneResource = new SceneResource(api);
+  const scenes = await sceneResource.getScenes();
+
+  t.deepEqual(scenes, []);
+  // when there are no scenes, we skip the room/zone fetch entirely
+  t.is(calls.length, 1);
+  t.is(calls[0].endpoint, "/clip/v2/resource/scene");
+});
+
+test("getScene maps empty data to NotFound HueError", async (t) => {
+  const { api } = makeMockApi({
+    [`/clip/v2/resource/scene/${ORPHAN_SCENE_ID}`]: { errors: [], data: [] } as SceneResourceResult
+  });
+
+  const sceneResource = new SceneResource(api);
+
+  await t.throwsAsync(() => sceneResource.getScene(ORPHAN_SCENE_ID), {
+    instanceOf: HueError,
+    message: "Scene resource not found"
+  });
+});
+
+test("recall defaults to action: 'active' and PUTs to the scene endpoint", async (t) => {
+  const recallResponse: SceneRecallResponse = {
+    errors: [],
+    data: [{ rid: SCENE_IN_ROOM_ID }]
+  };
+
+  const { api, calls } = makeMockApi({
+    [`/clip/v2/resource/scene/${SCENE_IN_ROOM_ID}`]: recallResponse
+  });
+
+  const sceneResource = new SceneResource(api);
+  const data = await sceneResource.recall(SCENE_IN_ROOM_ID);
+
+  t.is(calls.length, 1);
+  t.is(calls[0].method, "PUT");
+  t.is(calls[0].endpoint, `/clip/v2/resource/scene/${SCENE_IN_ROOM_ID}`);
+  t.deepEqual(calls[0].body, { recall: { action: "active" } });
+  t.deepEqual(data, [{ rid: SCENE_IN_ROOM_ID }]);
+});
+
+test("recall forwards an explicit action to the bridge", async (t) => {
+  const recallResponse: SceneRecallResponse = { errors: [], data: [{ rid: SCENE_IN_ROOM_ID }] };
+  const { api, calls } = makeMockApi({
+    [`/clip/v2/resource/scene/${SCENE_IN_ROOM_ID}`]: recallResponse
+  });
+
+  const sceneResource = new SceneResource(api);
+
+  await sceneResource.recall(SCENE_IN_ROOM_ID, "dynamic_palette");
+  t.deepEqual(calls.at(-1)?.body, { recall: { action: "dynamic_palette" } });
+
+  await sceneResource.recall(SCENE_IN_ROOM_ID, "static");
+  t.deepEqual(calls.at(-1)?.body, { recall: { action: "static" } });
+});

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,6 +1,7 @@
 import test from "ava";
 import {
   brightnessToPercent,
+  buildSceneOptionsForGroup,
   colorTempToMirek,
   convertHSVtoXY,
   convertXYtoHSV,
@@ -17,8 +18,10 @@ import {
   delay,
   convertImageToBase64,
   i18all,
-  isDeepEqual
+  isDeepEqual,
+  SCENE_NONE_OPTION
 } from "../src/util.js";
+import { SceneConfig } from "../src/config.js";
 import { LightFeatures } from "@unfoldedcircle/integration-api";
 import { CombinedGroupResource, GamutTriangle, LightResource } from "../src/lib/hue-api/types.js";
 import fs from "fs";
@@ -550,4 +553,48 @@ test("isDeepEqual handles undefined as non-existing", (t) => {
   t.true(isDeepEqual({ a: 1, b: undefined }, { a: 1 }));
   t.true(isDeepEqual({ a: 1, b: undefined }, { a: 1, c: undefined }));
   t.false(isDeepEqual({ a: 1 }, { a: 1, b: null }));
+});
+
+function makeScene(id: string, name: string, groupId = "g1"): SceneConfig & { id: string } {
+  return { id, name, groupId, groupRtype: "room", groupName: "Living Room" };
+}
+
+test("buildSceneOptionsForGroup returns an empty options array for an empty group", (t) => {
+  const result = buildSceneOptionsForGroup([]);
+  t.deepEqual(result.options, []);
+  t.is(result.optionToId.size, 0);
+  t.is(result.idToOption.size, 0);
+});
+
+test("buildSceneOptionsForGroup sorts scenes alphabetically without prepending a placeholder", (t) => {
+  const scenes = [makeScene("s1", "Bright"), makeScene("s2", "Cozy"), makeScene("s3", "Ambient")];
+  const result = buildSceneOptionsForGroup(scenes);
+  t.deepEqual(result.options, ["Ambient", "Bright", "Cozy"]);
+  t.false(result.options.includes(SCENE_NONE_OPTION), "placeholder is not embedded in helper output");
+  t.is(result.optionToId.get("Ambient"), "s3");
+  t.is(result.optionToId.get("Bright"), "s1");
+  t.is(result.optionToId.get("Cozy"), "s2");
+});
+
+test("buildSceneOptionsForGroup sorts case-insensitively", (t) => {
+  const scenes = [makeScene("s1", "bright"), makeScene("s2", "Ambient"), makeScene("s3", "Cozy")];
+  const result = buildSceneOptionsForGroup(scenes);
+  t.deepEqual(result.options, ["Ambient", "bright", "Cozy"]);
+});
+
+test("buildSceneOptionsForGroup suffixes duplicate scene names with (2), (3)", (t) => {
+  const scenes = [makeScene("s1", "Movie Night"), makeScene("s2", "Movie Night"), makeScene("s3", "Movie Night")];
+  const result = buildSceneOptionsForGroup(scenes);
+  t.deepEqual(result.options, ["Movie Night", "Movie Night (2)", "Movie Night (3)"]);
+  t.is(result.optionToId.get("Movie Night"), "s1");
+  t.is(result.optionToId.get("Movie Night (2)"), "s2");
+  t.is(result.optionToId.get("Movie Night (3)"), "s3");
+});
+
+test("buildSceneOptionsForGroup builds matching forward and reverse maps", (t) => {
+  const scenes = [makeScene("s1", "Bright"), makeScene("s2", "Bright")];
+  const result = buildSceneOptionsForGroup(scenes);
+  for (const [option, sceneId] of result.optionToId) {
+    t.is(result.idToOption.get(sceneId), option);
+  }
 });


### PR DESCRIPTION
> Updated since the original draft based on review input from @kennymc-c (per-group `Select` shape) and @henrikwidlund (drop the dynamics functionality due to added complexity). Both landed in this revision.

# Description

Adds Hue scene support, building on the rooms/zones foundation from #49.

Each Hue room or zone that has at least one scene is exposed as a `Select` entity named `<Group> scenes`. Its options are the group's scenes, sorted alphabetically, with name collisions deterministically suffixed `(2)`, `(3)`. Selecting an option calls `PUT /clip/v2/resource/scene/<id>` with `{ recall: { action: "active" } }` — the bridge auto-starts dynamics for scenes with `auto_dynamic: true`. When the group has no scene currently active, a `—` placeholder appears at the top of the dropdown and is the `current_option`. When a scene is active, `—` is removed from the options entirely — the dropdown only shows real scene names. Selecting `—` while it's visible is a no-op.

`current_option` follows the bridge's authoritative `scene.status.active` SSE updates, so the UI tracks activations from the Hue app and any other client. Selecting `—` from the remote is a no-op (the Hue API has no "deactivate scene" verb; clearing scene lighting is done via the group's Light entity).

## Trade-off vs. per-scene `Button`

The original draft used one `Button` per scene — pressing it sent a recall, and the integration didn't need to know anything else. The `Select` shape brings a state-tracking obligation: `current_option` must reflect reality, so we now subscribe to scene status SSE, refresh state on event-stream reconnect, and propagate scene add/update/delete to the affected group's Select. The cost is more code; the benefit is one entity per scene-having group instead of N entities per group, plus natural UI feedback when something changes the scene outside the remote.

## Persistence

- `SceneConfig` interface (separate `scenes` map on `Config` parallel to `lights`) is unchanged from the original draft.
- `CFG_VERSION` stayed at 4 — no schema change vs. the original; only the entity surface differs.
- Migration fetches scenes alongside lights/rooms/zones in `migrateConfig`.

## SSE handling

- `add` / `update` / `delete` for scenes flow into per-group Select rebuilds.
- `status.active` transitions update `current_option` for the affected group.
- Group rename cascades to scene `groupName` (denormalized on `SceneConfig`) and re-renders the Select entity name.
- Optimistic UI on remote-initiated recalls: the Select paints the new option immediately and fires the recall in the background. Awaiting the PUT response before painting causes visible UI lag — the bridge sometimes takes >1s on scene recalls — and on the worst case triggers Remote-side "not responding" command timeouts.

## Out of scope

- `smart_scene` (separate resource with scheduled-sequence semantics).
- Creating, editing, or deleting scenes from the remote (read + recall only).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Local: `rm -rf dist && npm run build` clean, `npm test` 69 passing (added 5 for `buildSceneOptionsForGroup` + 2 for `getActiveScenes`), `npm run code-check` clean.
- Hardware: validated on a Raspberry Pi running the integration as a systemd service against a Hue Bridge Pro on the same LAN, with bench setup including dynamic-palette scenes. Confirmed:
  - One `Select` entity per scene-having room/zone, options correctly sorted with collisions suffixed.
  - Remote-driven scene picks recall correctly; UI updates instantly (optimistic), bridge applies within typical RTT (~150–300ms; occasionally up to ~1s on slower scenes).
  - Hue-app-driven activations propagate via SSE within one round-trip; `current_option` tracks.
  - Group off / activating another scene reverts to `—` correctly.
  - Adding/renaming/deleting scenes in the Hue app updates the Select's options live, no restart required.
  - Renaming a room/zone updates the Select entity's name and area.
  - The `—` placeholder appears in the dropdown only when no scene is active for the group; the moment a scene becomes active (via the Remote or the Hue app), `—` disappears from the options. Returning to no-scene-active state restores it.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request represents one logical piece of work
- [x] My changes pass the linter checks `npm run code-check` and unit tests `npm run test`
- [x] I have tested and performed a self-review of my code
