### PR TITLE
feat: add Off option to the scene Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-_Changes in the next release_
+### Added
+
+- Scene `Select` entities now include an `Off` option that reflects the group's power state and turns the whole group off when selected by @stakats ([#150](https://github.com/unfoldedcircle/integration-philipshue/pull/150)).
+
+### Fixed
+
+- A scene named like the `Off` or `—` option is no longer shadowed — such scenes stay selectable and recallable by @stakats ([#150](https://github.com/unfoldedcircle/integration-philipshue/pull/150)).
 
 ---
 

--- a/src/lib/philips-hue.ts
+++ b/src/lib/philips-hue.ts
@@ -40,7 +40,8 @@ import {
   getMostCommonGamut,
   mirekToColorTemp,
   percentToBrightness,
-  SCENE_NONE_OPTION
+  SCENE_NONE_OPTION,
+  SCENE_OFF_OPTION
 } from "../util.js";
 import HueApi, { HueError } from "./hue-api/api.js";
 import HueEventStream from "./hue-api/event-stream.js";
@@ -74,6 +75,11 @@ class PhilipsHue {
   // so SSE handlers (status.active transitions) can find the option in O(1).
   private sceneOptionToId: Map<string, Map<string, string>> = new Map();
   private sceneIdToOption: Map<string, { groupId: string; option: string }> = new Map();
+  // Tracks the last-known on/off state of each group that has a scene Select, keyed by
+  // groupId. Drives the `Off` current_option / placeholder distinction without depending on
+  // whether the group's Light entity is configured. Populated from grouped_light SSE events
+  // and syncGroupState; absent entry => assume on (show the `—` placeholder).
+  private groupPowerOn: Map<string, boolean> = new Map();
 
   constructor() {
     this.uc = new IntegrationAPI();
@@ -515,7 +521,7 @@ class PhilipsHue {
     }
 
     const currentOption = this.deriveCurrentOptionForGroup(groupId) ?? SCENE_NONE_OPTION;
-    const options = this.computeOptionsForGroup(groupId, currentOption !== SCENE_NONE_OPTION);
+    const options = this.computeOptionsForGroup(groupId, currentOption);
 
     const groupName = groupScenes[0].groupName;
     const entityId = this.getSceneSelectEntityId(groupId);
@@ -546,14 +552,17 @@ class PhilipsHue {
   }
 
   /**
-   * Build the options array for a group's Select, inserting the `—` placeholder only when no
-   * scene is currently active. The placeholder represents the current state when it's shown,
-   * so it disappears from the dropdown the moment any scene becomes active.
+   * Build the options array for a group's Select given its resolved `current_option`.
+   *
+   * `Off` is always present and selectable (turning it on turns the whole group off). The `—`
+   * placeholder is included only when it is the current option (group on, no scene active), so
+   * it disappears from the dropdown the moment a scene becomes active or the group turns off.
    */
-  private computeOptionsForGroup(groupId: string, sceneActive: boolean): string[] {
+  private computeOptionsForGroup(groupId: string, currentOption: string): string[] {
     const optionToId = this.sceneOptionToId.get(groupId);
     const sceneOptions = optionToId ? [...optionToId.keys()] : [];
-    return sceneActive ? sceneOptions : [SCENE_NONE_OPTION, ...sceneOptions];
+    const placeholder = currentOption === SCENE_NONE_OPTION ? [SCENE_NONE_OPTION] : [];
+    return [...placeholder, SCENE_OFF_OPTION, ...sceneOptions];
   }
 
   private removeSceneSelectForGroup(groupId: string) {
@@ -581,19 +590,21 @@ class PhilipsHue {
     if (!existing) {
       return undefined;
     }
+    // The non-scene sentinel reflects current group power: `Off` when off, `—` when on.
+    const noScene = this.groupPowerOn.get(groupId) === false ? SCENE_OFF_OPTION : SCENE_NONE_OPTION;
     const prevOption = (existing.attributes?.[SelectAttributes.CurrentOption] as string | undefined) ?? undefined;
-    if (!prevOption || prevOption === SCENE_NONE_OPTION) {
-      return SCENE_NONE_OPTION;
+    if (!prevOption || prevOption === SCENE_NONE_OPTION || prevOption === SCENE_OFF_OPTION) {
+      return noScene;
     }
     // If the previously-active scene still exists in this group, remap its label (it may
-    // have been renamed). Otherwise, fall back to the placeholder.
+    // have been renamed). Otherwise, fall back to the power-based sentinel.
     const optionToId = this.sceneOptionToId.get(groupId);
     const sceneId = optionToId?.get(prevOption);
     if (sceneId) {
       const mapping = this.sceneIdToOption.get(sceneId);
-      return mapping?.option ?? SCENE_NONE_OPTION;
+      return mapping?.option ?? noScene;
     }
-    return SCENE_NONE_OPTION;
+    return noScene;
   }
 
   /**
@@ -601,22 +612,58 @@ class PhilipsHue {
    * observed or undefined to revert to "no scene active".
    *
    * Broadcasts both `current_option` and `options` in the same entity_change so the Remote
-   * sees a consistent snapshot: when a scene is active, the placeholder is absent from
-   * `options`; when no scene is active, the placeholder is present and is the current option.
+   * sees a consistent snapshot. With no active scene, the current option reflects the group's
+   * power: `Off` when off, the `—` placeholder when on (the placeholder then appears in
+   * `options`; `Off` is always present and selectable).
    */
   private setSelectCurrentOption(groupId: string, sceneId: string | undefined) {
     const entityId = this.getSceneSelectEntityId(groupId);
     if (!this.uc.getAvailableEntities().contains(entityId)) {
       return;
     }
-    const option = sceneId ? (this.sceneIdToOption.get(sceneId)?.option ?? SCENE_NONE_OPTION) : SCENE_NONE_OPTION;
-    const sceneActive = option !== SCENE_NONE_OPTION;
+    let option: string;
+    if (sceneId) {
+      // An active scene implies the group is on; show the scene regardless of power state.
+      option = this.sceneIdToOption.get(sceneId)?.option ?? SCENE_NONE_OPTION;
+    } else {
+      // No active scene: reflect the group's power — `Off` when off, `—` placeholder when on.
+      option = this.groupPowerOn.get(groupId) === false ? SCENE_OFF_OPTION : SCENE_NONE_OPTION;
+    }
     const updates = {
       [SelectAttributes.CurrentOption]: option,
-      [SelectAttributes.Options]: this.computeOptionsForGroup(groupId, sceneActive)
+      [SelectAttributes.Options]: this.computeOptionsForGroup(groupId, option)
     };
     this.uc.getConfiguredEntities().updateEntityAttributes(entityId, updates);
     this.uc.getAvailableEntities().updateEntityAttributes(entityId, updates);
+  }
+
+  /**
+   * Record a group's on/off state and reconcile its scene Select's `Off`/`—` sentinel.
+   *
+   * Fed from grouped_light SSE events and {@link syncGroupState}. Only groups that have a
+   * scene Select are reconciled. On a power change we move the sentinel — but when the group
+   * turns on we only act if the Select currently shows `Off`, so a concurrently-activated
+   * scene (whose SSE event may arrive before or after the power event) is never clobbered.
+   */
+  private recordGroupPowerForScenes(groupId: string, on: boolean) {
+    const prev = this.groupPowerOn.get(groupId);
+    this.groupPowerOn.set(groupId, on);
+    if (prev === on || !this.sceneOptionToId.has(groupId)) {
+      return;
+    }
+    const entityId = this.getSceneSelectEntityId(groupId);
+    const current = this.uc.getAvailableEntities().getEntity(entityId)?.attributes?.[SelectAttributes.CurrentOption] as
+      | string
+      | undefined;
+    if (!on) {
+      // Group turned off: show `Off`, clearing any active scene or placeholder.
+      if (current !== SCENE_OFF_OPTION) {
+        this.setSelectCurrentOption(groupId, undefined);
+      }
+    } else if (current === SCENE_OFF_OPTION) {
+      // Group turned on with no scene yet: move `Off` back to the `—` placeholder.
+      this.setSelectCurrentOption(groupId, undefined);
+    }
   }
 
   private async onSceneSelectCommand(
@@ -678,6 +725,29 @@ class PhilipsHue {
     if (targetOption === undefined) {
       log.warn("onSceneSelectCommand: missing `option` parameter for select_option");
       return StatusCodes.BadRequest;
+    }
+
+    if (targetOption === SCENE_OFF_OPTION) {
+      const groupConfig = this.config.getLight(groupId);
+      if (!groupConfig || !this.isGroupConfig(groupConfig)) {
+        log.warn("onSceneSelectCommand: no group config for %s; cannot turn off", groupId);
+        return StatusCodes.BadRequest;
+      }
+      // Optimistic UI: paint `Off` immediately, then turn the whole group off. Same call the
+      // group's Light entity makes (PUT /grouped_light/<id> {on:{on:false}}), fanned out over
+      // the group's grouped_light ids. SSE reaffirms on success; we revert on failure.
+      this.groupPowerOn.set(groupId, false);
+      this.setSelectCurrentOption(groupId, undefined); // resolves to `Off`
+      Promise.all(
+        groupConfig.groupedLightIds.map((groupedLightId) =>
+          this.hueApi.lightResource.setOn(groupedLightId, false, false)
+        )
+      ).catch((error) => {
+        log.error("Turning group %s off from scene Select failed, reverting:", groupId, error);
+        this.groupPowerOn.set(groupId, true);
+        this.setSelectCurrentOption(groupId, undefined);
+      });
+      return StatusCodes.Ok;
     }
 
     if (targetOption === SCENE_NONE_OPTION) {
@@ -750,6 +820,13 @@ class PhilipsHue {
         this.syncLightState(entityId, data).catch((error) =>
           log.error("Syncing lights failed for event stream update:", error)
         );
+
+        // Track group power for the scene Select's `Off`/`—` sentinel. Done here (not inside
+        // syncLightState, which bails when the group's Light entity isn't configured) so the
+        // Select stays correct even if only the scene Select is configured.
+        if (data.type === "grouped_light" && data.on && typeof data.on === "object" && "on" in data.on) {
+          this.recordGroupPowerForScenes(entityId, !!data.on.on);
+        }
 
         // grouped_light can't be updated, they are a compound of multiple devices and belong to a room/zone
         if (data.type === "light") {
@@ -1189,6 +1266,11 @@ class PhilipsHue {
       groupState[LightAttributes.State] = LightStates.On;
     } else if (anyOff) {
       groupState[LightAttributes.State] = LightStates.Off;
+    }
+    // Keep the group's scene Select `Off`/`—` sentinel in sync (covers initial load and
+    // room/zone events). Only when the grouped lights actually reported a power state.
+    if (anyOn || anyOff) {
+      this.recordGroupPowerForScenes(entityId, anyOn);
     }
 
     const dimming = groupedLights?.find((groupLight) => groupLight.dimming);

--- a/src/lib/philips-hue.ts
+++ b/src/lib/philips-hue.ts
@@ -28,7 +28,7 @@ import {
   addAvailableLights,
   addAvailableScenes,
   brightnessToPercent,
-  buildSceneOptionsForGroup,
+  buildSceneSelectOptions,
   colorTempToMirek,
   convertHSVtoXY,
   convertXYtoHSV,
@@ -38,12 +38,12 @@ import {
   getLightFeatures,
   getMinMaxMirek,
   getMostCommonGamut,
-  isOffOption,
   localize,
   mirekToColorTemp,
   OFF_LABEL_KEY,
   percentToBrightness,
-  SCENE_NONE_OPTION
+  SCENE_NONE_OPTION,
+  SceneSelectOption
 } from "../util.js";
 import HueApi, { HueError } from "./hue-api/api.js";
 import HueEventStream from "./hue-api/event-stream.js";
@@ -71,12 +71,12 @@ class PhilipsHue {
   // migration guard flag
   private migrating = false;
   // Per-group scene Select state. Each group with scenes gets one Select entity named
-  // "<Group> scenes"; these maps translate between the option label shown to the user
-  // and the underlying Hue scene id. Forward map is keyed by groupId so we can wholesale
-  // rebuild a group's Select on scene add/remove/rename; reverse map is keyed by sceneId
-  // so SSE handlers (status.active transitions) can find the option in O(1).
-  private sceneOptionToId: Map<string, Map<string, string>> = new Map();
-  private sceneIdToOption: Map<string, { groupId: string; option: string }> = new Map();
+  // "<Group> scenes". The model is the single source of truth for that group's options: an
+  // ordered, unique-labelled catalog of descriptors ([off, none, ...scenes]) that owns both
+  // the emitted option labels and how a selected label dispatches (turn off / no-op / recall).
+  // Keyed by groupId so a group's Select rebuilds wholesale on scene add/remove/rename or a
+  // language change.
+  private sceneSelectModel: Map<string, SceneSelectOption[]> = new Map();
   // Tracks the last-known on/off state of each group that has a scene Select, keyed by
   // groupId. Drives the `Off` current_option / placeholder distinction without depending on
   // whether the group's Light entity is configured. Populated from grouped_light SSE events
@@ -225,7 +225,7 @@ class PhilipsHue {
       }
     }
     // Remove Select entities for groups that no longer have scenes
-    for (const groupId of this.sceneOptionToId.keys()) {
+    for (const groupId of this.sceneSelectModel.keys()) {
       if (!scenesByGroup.has(groupId)) {
         this.removeSceneSelectForGroup(groupId);
       }
@@ -243,8 +243,8 @@ class PhilipsHue {
    * Node SDK (v0.5.0) exposes no way to query the remote's active language — only the Python
    * `ucapi` lib has `get_localization_cfg`. Once that lands in the Node SDK, replace this body
    * with a poll of the remote's language on connect (validated against the locale set in
-   * driver.ts), mirroring kennymc-c's pattern. Everything downstream (offLabel/isOffOption,
-   * applyLanguage's rebuild) already handles a non-English result.
+   * driver.ts), mirroring kennymc-c's pattern. Everything downstream (the descriptor catalog's
+   * off label, applyLanguage's rebuild) already handles a non-English result.
    */
   private resolveLanguage(): string {
     return "en";
@@ -265,6 +265,25 @@ class PhilipsHue {
   /** The scene Select "Off" option label in the active language. */
   private offLabel(): string {
     return localize(OFF_LABEL_KEY, this.language);
+  }
+
+  /** Resolve an emitted option label back to its descriptor for the given group. */
+  private findOption(groupId: string, label: string): SceneSelectOption | undefined {
+    return this.sceneSelectModel.get(groupId)?.find((o) => o.label === label);
+  }
+
+  /** Find a group's descriptor for the given scene id, if that scene is in its Select. */
+  private findSceneOption(groupId: string, sceneId: string): SceneSelectOption | undefined {
+    return this.sceneSelectModel.get(groupId)?.find((o) => o.kind === "scene" && o.sceneId === sceneId);
+  }
+
+  /**
+   * The label to show when no scene is active: the group's localized "Off" descriptor when the
+   * group is off, otherwise the `—` placeholder.
+   */
+  private noSceneLabel(groupId: string): string {
+    const off = this.sceneSelectModel.get(groupId)?.find((o) => o.kind === "off");
+    return this.groupPowerOn.get(groupId) === false && off ? off.label : SCENE_NONE_OPTION;
   }
 
   private updateEntityIndexes() {
@@ -345,8 +364,8 @@ class PhilipsHue {
     // removing entities with a single bridge is easy
     this.uc.clearConfiguredEntities();
     this.uc.clearAvailableEntities();
-    this.sceneOptionToId.clear();
-    this.sceneIdToOption.clear();
+    this.sceneSelectModel.clear();
+    this.groupPowerOn.clear();
   }
 
   // terri: check if you can simplify since
@@ -545,20 +564,10 @@ class PhilipsHue {
       return;
     }
 
-    const { optionToId, idToOption } = buildSceneOptionsForGroup(groupScenes);
-    this.sceneOptionToId.set(groupId, optionToId);
-    // Refresh the reverse-direction map: drop stale entries for this group, then re-add.
-    for (const [sceneId, mapping] of this.sceneIdToOption) {
-      if (mapping.groupId === groupId) {
-        this.sceneIdToOption.delete(sceneId);
-      }
-    }
-    for (const [sceneId, option] of idToOption) {
-      this.sceneIdToOption.set(sceneId, { groupId, option });
-    }
+    this.sceneSelectModel.set(groupId, buildSceneSelectOptions(groupScenes, this.offLabel()));
 
-    const currentOption = this.deriveCurrentOptionForGroup(groupId) ?? SCENE_NONE_OPTION;
-    const options = this.computeOptionsForGroup(groupId, currentOption);
+    const currentOption = this.deriveCurrentOptionForGroup(groupId);
+    const options = this.optionsForCurrent(groupId, currentOption);
 
     const groupName = groupScenes[0].groupName;
     const entityId = this.getSceneSelectEntityId(groupId);
@@ -589,59 +598,51 @@ class PhilipsHue {
   }
 
   /**
-   * Build the options array for a group's Select given its resolved `current_option`.
+   * Build the emitted options array for a group's Select given its resolved `current_option`.
    *
-   * `Off` is always present and selectable (turning it on turns the whole group off). The `—`
-   * placeholder is included only when it is the current option (group on, no scene active), so
-   * it disappears from the dropdown the moment a scene becomes active or the group turns off.
+   * Derived from the descriptor catalog: `Off` and the scenes are always present and
+   * selectable; the `—` placeholder appears only when it is the current option (group on, no
+   * scene active), so it disappears the moment a scene becomes active or the group turns off.
    */
-  private computeOptionsForGroup(groupId: string, currentOption: string): string[] {
-    const optionToId = this.sceneOptionToId.get(groupId);
-    const sceneOptions = optionToId ? [...optionToId.keys()] : [];
-    const placeholder = currentOption === SCENE_NONE_OPTION ? [SCENE_NONE_OPTION] : [];
-    return [...placeholder, this.offLabel(), ...sceneOptions];
+  private optionsForCurrent(groupId: string, currentOption: string): string[] {
+    const model = this.sceneSelectModel.get(groupId) ?? [];
+    const result: string[] = [];
+    const none = model.find((o) => o.kind === "none");
+    if (none && currentOption === none.label) {
+      result.push(none.label);
+    }
+    const off = model.find((o) => o.kind === "off");
+    if (off) {
+      result.push(off.label);
+    }
+    result.push(...model.filter((o) => o.kind === "scene").map((o) => o.label));
+    return result;
   }
 
   private removeSceneSelectForGroup(groupId: string) {
-    this.sceneOptionToId.delete(groupId);
-    for (const [sceneId, mapping] of this.sceneIdToOption) {
-      if (mapping.groupId === groupId) {
-        this.sceneIdToOption.delete(sceneId);
-      }
-    }
+    this.sceneSelectModel.delete(groupId);
     const entityId = this.getSceneSelectEntityId(groupId);
     this.uc.getConfiguredEntities().removeEntity(entityId);
     this.uc.getAvailableEntities().removeEntity(entityId);
   }
 
   /**
-   * Find the option string that should currently be shown for a group's Select.
+   * Find the option label that should currently be shown for a group's Select after a rebuild.
    *
-   * Returns the active scene's option label if one is set on the group's existing Select,
-   * mapped through the (possibly just-rebuilt) options. Returns undefined if there's no
-   * Select yet for this group (caller decides what to seed).
+   * Preserves the selection only if the previously-shown label still maps to a real scene
+   * descriptor; sentinels and stale labels collapse to the power-based no-scene label (`Off`
+   * when off, `—` when on). Returns the no-scene label if there's no existing Select.
    */
-  private deriveCurrentOptionForGroup(groupId: string): string | undefined {
+  private deriveCurrentOptionForGroup(groupId: string): string {
+    const noScene = this.noSceneLabel(groupId);
     const entityId = this.getSceneSelectEntityId(groupId);
     const existing = this.uc.getAvailableEntities().getEntity(entityId);
-    if (!existing) {
-      return undefined;
-    }
-    // The non-scene sentinel reflects current group power: `Off` when off, `—` when on.
-    const noScene = this.groupPowerOn.get(groupId) === false ? this.offLabel() : SCENE_NONE_OPTION;
-    const prevOption = (existing.attributes?.[SelectAttributes.CurrentOption] as string | undefined) ?? undefined;
-    if (!prevOption || prevOption === SCENE_NONE_OPTION || isOffOption(prevOption)) {
+    const prevOption = existing?.attributes?.[SelectAttributes.CurrentOption] as string | undefined;
+    if (!prevOption) {
       return noScene;
     }
-    // If the previously-active scene still exists in this group, remap its label (it may
-    // have been renamed). Otherwise, fall back to the power-based sentinel.
-    const optionToId = this.sceneOptionToId.get(groupId);
-    const sceneId = optionToId?.get(prevOption);
-    if (sceneId) {
-      const mapping = this.sceneIdToOption.get(sceneId);
-      return mapping?.option ?? noScene;
-    }
-    return noScene;
+    const desc = this.findOption(groupId, prevOption);
+    return desc?.kind === "scene" ? desc.label : noScene;
   }
 
   /**
@@ -658,17 +659,14 @@ class PhilipsHue {
     if (!this.uc.getAvailableEntities().contains(entityId)) {
       return;
     }
-    let option: string;
-    if (sceneId) {
-      // An active scene implies the group is on; show the scene regardless of power state.
-      option = this.sceneIdToOption.get(sceneId)?.option ?? SCENE_NONE_OPTION;
-    } else {
-      // No active scene: reflect the group's power — `Off` when off, `—` placeholder when on.
-      option = this.groupPowerOn.get(groupId) === false ? this.offLabel() : SCENE_NONE_OPTION;
-    }
+    // An active scene implies the group is on; show the scene regardless of power state.
+    // Otherwise reflect group power via the no-scene label.
+    const option = sceneId
+      ? (this.findSceneOption(groupId, sceneId)?.label ?? this.noSceneLabel(groupId))
+      : this.noSceneLabel(groupId);
     const updates = {
       [SelectAttributes.CurrentOption]: option,
-      [SelectAttributes.Options]: this.computeOptionsForGroup(groupId, option)
+      [SelectAttributes.Options]: this.optionsForCurrent(groupId, option)
     };
     this.uc.getConfiguredEntities().updateEntityAttributes(entityId, updates);
     this.uc.getAvailableEntities().updateEntityAttributes(entityId, updates);
@@ -685,19 +683,20 @@ class PhilipsHue {
   private recordGroupPowerForScenes(groupId: string, on: boolean) {
     const prev = this.groupPowerOn.get(groupId);
     this.groupPowerOn.set(groupId, on);
-    if (prev === on || !this.sceneOptionToId.has(groupId)) {
+    if (prev === on || !this.sceneSelectModel.has(groupId)) {
       return;
     }
     const entityId = this.getSceneSelectEntityId(groupId);
     const current = this.uc.getAvailableEntities().getEntity(entityId)?.attributes?.[SelectAttributes.CurrentOption] as
       | string
       | undefined;
+    const showingOff = current !== undefined && this.findOption(groupId, current)?.kind === "off";
     if (!on) {
       // Group turned off: show `Off`, clearing any active scene or placeholder.
-      if (!current || !isOffOption(current)) {
+      if (!showingOff) {
         this.setSelectCurrentOption(groupId, undefined);
       }
-    } else if (current && isOffOption(current)) {
+    } else if (showingOff) {
       // Group turned on with no scene yet: move `Off` back to the `—` placeholder.
       this.setSelectCurrentOption(groupId, undefined);
     }
@@ -713,8 +712,7 @@ class PhilipsHue {
       log.error("onSceneSelectCommand: entity id %s is not a scene Select", entity.id);
       return StatusCodes.BadRequest;
     }
-    const optionToId = this.sceneOptionToId.get(groupId);
-    if (!optionToId) {
+    if (!this.sceneSelectModel.has(groupId)) {
       log.warn("onSceneSelectCommand: no options registered for group %s", groupId);
       return StatusCodes.BadRequest;
     }
@@ -764,58 +762,58 @@ class PhilipsHue {
       return StatusCodes.BadRequest;
     }
 
-    // Matched against the "Off" label in any supported language, so it resolves even if the
-    // UI language changed between sending the options and this command arriving. Known
-    // limitation (same class as the `—` placeholder): a scene named literally "Off"/"Aus"/
-    // "Éteint" would be treated as the off sentinel rather than recalled.
-    if (isOffOption(targetOption)) {
-      const groupConfig = this.config.getLight(groupId);
-      if (!groupConfig || !this.isGroupConfig(groupConfig)) {
-        log.warn("onSceneSelectCommand: no group config for %s; cannot turn off", groupId);
-        return StatusCodes.BadRequest;
-      }
-      // Optimistic UI: paint `Off` immediately, then turn the whole group off. Same call the
-      // group's Light entity makes (PUT /grouped_light/<id> {on:{on:false}}), fanned out over
-      // the group's grouped_light ids. SSE reaffirms on success; we revert on failure.
-      this.groupPowerOn.set(groupId, false);
-      this.setSelectCurrentOption(groupId, undefined); // resolves to `Off`
-      Promise.all(
-        groupConfig.groupedLightIds.map((groupedLightId) =>
-          this.hueApi.lightResource.setOn(groupedLightId, false, false)
-        )
-      ).catch((error) => {
-        log.error("Turning group %s off from scene Select failed, reverting:", groupId, error);
-        this.groupPowerOn.set(groupId, true);
-        this.setSelectCurrentOption(groupId, undefined);
-      });
-      return StatusCodes.Ok;
-    }
-
-    if (targetOption === SCENE_NONE_OPTION) {
-      // Selecting the placeholder is a no-op — the Hue API has no "deactivate scene" verb.
-      // The Select stays where it is (the bridge will resolve current_option via SSE if anything
-      // actually changed).
-      return StatusCodes.Ok;
-    }
-
-    const sceneId = optionToId.get(targetOption);
-    if (!sceneId) {
+    // Resolve the label to its descriptor and dispatch by kind. Because labels are unique
+    // within the catalog, a scene named like a sentinel ("Off"/"—") is its own `scene`
+    // descriptor (suffixed to "Off (2)" etc.) and recalls normally — no collision.
+    const target = this.findOption(groupId, targetOption);
+    if (!target) {
       log.warn("onSceneSelectCommand: option %s not recognized for group %s", targetOption, groupId);
       return StatusCodes.BadRequest;
     }
 
-    // Optimistic UI: paint the new option immediately so the remote doesn't sit in a "pending"
-    // state while the bridge processes. Recall is fire-and-forget; SSE will reaffirm on success
-    // and we revert on failure. The bridge's PUT /scene response can take >1.5s; awaiting it
-    // would block this handler (and the remote's UI) for the full RTT plus any retries.
-    this.setSelectCurrentOption(groupId, sceneId);
-    this.hueApi.sceneResource.recall(sceneId).catch((error) => {
-      log.error("Scene recall failed for %s, reverting Select to placeholder:", sceneId, error);
-      // We don't actually know which scene (if any) the bridge is currently in; safest is to
-      // revert to the placeholder. SSE will correct if some other scene was already active.
-      this.setSelectCurrentOption(groupId, undefined);
-    });
-    return StatusCodes.Ok;
+    switch (target.kind) {
+      case "none":
+        // Selecting the placeholder is a no-op — the Hue API has no "deactivate scene" verb.
+        // The Select stays where it is (SSE will resolve current_option if anything changed).
+        return StatusCodes.Ok;
+
+      case "off": {
+        const groupConfig = this.config.getLight(groupId);
+        if (!groupConfig || !this.isGroupConfig(groupConfig)) {
+          log.warn("onSceneSelectCommand: no group config for %s; cannot turn off", groupId);
+          return StatusCodes.BadRequest;
+        }
+        // Optimistic UI: paint `Off` immediately, then turn the whole group off. Same call the
+        // group's Light entity makes (PUT /grouped_light/<id> {on:{on:false}}), fanned out over
+        // the group's grouped_light ids. SSE reaffirms on success; we revert on failure.
+        this.groupPowerOn.set(groupId, false);
+        this.setSelectCurrentOption(groupId, undefined); // resolves to `Off`
+        Promise.all(
+          groupConfig.groupedLightIds.map((groupedLightId) =>
+            this.hueApi.lightResource.setOn(groupedLightId, false, false)
+          )
+        ).catch((error) => {
+          log.error("Turning group %s off from scene Select failed, reverting:", groupId, error);
+          this.groupPowerOn.set(groupId, true);
+          this.setSelectCurrentOption(groupId, undefined);
+        });
+        return StatusCodes.Ok;
+      }
+
+      case "scene":
+        // Optimistic UI: paint the new option immediately so the remote doesn't sit in a
+        // "pending" state while the bridge processes. Recall is fire-and-forget; SSE reaffirms
+        // on success and we revert on failure. The bridge's PUT /scene response can take >1.5s;
+        // awaiting it would block this handler (and the remote's UI) for the full RTT.
+        this.setSelectCurrentOption(groupId, target.sceneId);
+        this.hueApi.sceneResource.recall(target.sceneId).catch((error) => {
+          log.error("Scene recall failed for %s, reverting Select to placeholder:", target.sceneId, error);
+          // We don't know which scene (if any) the bridge is now in; revert to the no-scene
+          // label. SSE will correct if some other scene was already active.
+          this.setSelectCurrentOption(groupId, undefined);
+        });
+        return StatusCodes.Ok;
+    }
   }
 
   private getMirek(entityId: string, config?: LightOrGroupConfig) {
@@ -945,13 +943,14 @@ class PhilipsHue {
           } else {
             // Only clear if this scene is the one currently shown — another scene becoming
             // active will already have moved the Select away from this one.
-            const mapping = this.sceneIdToOption.get(data.id);
-            if (mapping) {
-              const entityId = this.getSceneSelectEntityId(mapping.groupId);
+            const groupId = sceneCfg.groupId;
+            const desc = this.findSceneOption(groupId, data.id);
+            if (desc) {
+              const entityId = this.getSceneSelectEntityId(groupId);
               const existing = this.uc.getAvailableEntities().getEntity(entityId);
               const currentOption = existing?.attributes?.[SelectAttributes.CurrentOption] as string | undefined;
-              if (currentOption === mapping.option) {
-                this.setSelectCurrentOption(mapping.groupId, undefined);
+              if (currentOption === desc.label) {
+                this.setSelectCurrentOption(groupId, undefined);
               }
             }
           }
@@ -1143,7 +1142,7 @@ class PhilipsHue {
    * transition.
    */
   private async refreshSceneSelectStates() {
-    if (this.sceneOptionToId.size === 0) {
+    if (this.sceneSelectModel.size === 0) {
       return;
     }
     try {
@@ -1152,7 +1151,7 @@ class PhilipsHue {
       for (const scene of activeScenes) {
         activeByGroup.set(scene.groupId, scene.id);
       }
-      for (const groupId of this.sceneOptionToId.keys()) {
+      for (const groupId of this.sceneSelectModel.keys()) {
         this.setSelectCurrentOption(groupId, activeByGroup.get(groupId));
       }
     } catch (error) {

--- a/src/lib/philips-hue.ts
+++ b/src/lib/philips-hue.ts
@@ -38,10 +38,12 @@ import {
   getLightFeatures,
   getMinMaxMirek,
   getMostCommonGamut,
+  isOffOption,
+  localize,
   mirekToColorTemp,
+  OFF_LABEL_KEY,
   percentToBrightness,
-  SCENE_NONE_OPTION,
-  SCENE_OFF_OPTION
+  SCENE_NONE_OPTION
 } from "../util.js";
 import HueApi, { HueError } from "./hue-api/api.js";
 import HueEventStream from "./hue-api/event-stream.js";
@@ -80,6 +82,9 @@ class PhilipsHue {
   // whether the group's Light entity is configured. Populated from grouped_light SSE events
   // and syncGroupState; absent entry => assume on (show the `—` placeholder).
   private groupPowerOn: Map<string, boolean> = new Map();
+  // Active UI language for localizing runtime entity strings (currently the scene Select
+  // "Off" option). Resolved on connect via resolveLanguage(); defaults to English.
+  private language = "en";
 
   constructor() {
     this.uc = new IntegrationAPI();
@@ -228,6 +233,38 @@ class PhilipsHue {
     for (const [groupId, scenes] of scenesByGroup) {
       this.rebuildSceneSelectForGroup(groupId, scenes);
     }
+  }
+
+  /**
+   * Resolve the UI language used to localize runtime entity strings (the scene Select "Off"
+   * option). Returns English for now.
+   *
+   * **Single swap point** for the localization source. The `@unfoldedcircle/integration-api`
+   * Node SDK (v0.5.0) exposes no way to query the remote's active language — only the Python
+   * `ucapi` lib has `get_localization_cfg`. Once that lands in the Node SDK, replace this body
+   * with a poll of the remote's language on connect (validated against the locale set in
+   * driver.ts), mirroring kennymc-c's pattern. Everything downstream (offLabel/isOffOption,
+   * applyLanguage's rebuild) already handles a non-English result.
+   */
+  private resolveLanguage(): string {
+    return "en";
+  }
+
+  /**
+   * Apply a UI language. If it changed, rebuild every group's scene Select so the localized
+   * "Off" option (label and, when current, `current_option`) is re-emitted.
+   */
+  private applyLanguage(language: string) {
+    if (language === this.language) {
+      return;
+    }
+    this.language = language;
+    this.rebuildAllSceneSelects();
+  }
+
+  /** The scene Select "Off" option label in the active language. */
+  private offLabel(): string {
+    return localize(OFF_LABEL_KEY, this.language);
   }
 
   private updateEntityIndexes() {
@@ -562,7 +599,7 @@ class PhilipsHue {
     const optionToId = this.sceneOptionToId.get(groupId);
     const sceneOptions = optionToId ? [...optionToId.keys()] : [];
     const placeholder = currentOption === SCENE_NONE_OPTION ? [SCENE_NONE_OPTION] : [];
-    return [...placeholder, SCENE_OFF_OPTION, ...sceneOptions];
+    return [...placeholder, this.offLabel(), ...sceneOptions];
   }
 
   private removeSceneSelectForGroup(groupId: string) {
@@ -591,9 +628,9 @@ class PhilipsHue {
       return undefined;
     }
     // The non-scene sentinel reflects current group power: `Off` when off, `—` when on.
-    const noScene = this.groupPowerOn.get(groupId) === false ? SCENE_OFF_OPTION : SCENE_NONE_OPTION;
+    const noScene = this.groupPowerOn.get(groupId) === false ? this.offLabel() : SCENE_NONE_OPTION;
     const prevOption = (existing.attributes?.[SelectAttributes.CurrentOption] as string | undefined) ?? undefined;
-    if (!prevOption || prevOption === SCENE_NONE_OPTION || prevOption === SCENE_OFF_OPTION) {
+    if (!prevOption || prevOption === SCENE_NONE_OPTION || isOffOption(prevOption)) {
       return noScene;
     }
     // If the previously-active scene still exists in this group, remap its label (it may
@@ -627,7 +664,7 @@ class PhilipsHue {
       option = this.sceneIdToOption.get(sceneId)?.option ?? SCENE_NONE_OPTION;
     } else {
       // No active scene: reflect the group's power — `Off` when off, `—` placeholder when on.
-      option = this.groupPowerOn.get(groupId) === false ? SCENE_OFF_OPTION : SCENE_NONE_OPTION;
+      option = this.groupPowerOn.get(groupId) === false ? this.offLabel() : SCENE_NONE_OPTION;
     }
     const updates = {
       [SelectAttributes.CurrentOption]: option,
@@ -657,10 +694,10 @@ class PhilipsHue {
       | undefined;
     if (!on) {
       // Group turned off: show `Off`, clearing any active scene or placeholder.
-      if (current !== SCENE_OFF_OPTION) {
+      if (!current || !isOffOption(current)) {
         this.setSelectCurrentOption(groupId, undefined);
       }
-    } else if (current === SCENE_OFF_OPTION) {
+    } else if (current && isOffOption(current)) {
       // Group turned on with no scene yet: move `Off` back to the `—` placeholder.
       this.setSelectCurrentOption(groupId, undefined);
     }
@@ -727,7 +764,11 @@ class PhilipsHue {
       return StatusCodes.BadRequest;
     }
 
-    if (targetOption === SCENE_OFF_OPTION) {
+    // Matched against the "Off" label in any supported language, so it resolves even if the
+    // UI language changed between sending the options and this command arriving. Known
+    // limitation (same class as the `—` placeholder): a scene named literally "Off"/"Aus"/
+    // "Éteint" would be treated as the off sentinel rather than recalled.
+    if (isOffOption(targetOption)) {
       const groupConfig = this.config.getLight(groupId);
       if (!groupConfig || !this.isGroupConfig(groupConfig)) {
         log.warn("onSceneSelectCommand: no group config for %s; cannot turn off", groupId);
@@ -796,6 +837,9 @@ class PhilipsHue {
 
   private async handleConnect() {
     log.debug("Got connect event");
+    // Resolve the UI language before refreshing entities so scene Selects emit the localized
+    // "Off" label. updateLights() -> refreshSceneSelectStates() re-pushes every group's Select.
+    this.applyLanguage(this.resolveLanguage());
     // make sure the integration state is set
     await this.uc.setDeviceState(DeviceStates.Connected);
     this.updateLights().catch((error) => log.error("Updating lights failed:", error));

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -31,5 +31,8 @@
       "not_configured": "Kein Hub konfiguriert.",
       "lights": "Verfügbare Lichter"
     }
+  },
+  "scenes": {
+    "off": "Aus"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -31,5 +31,8 @@
       "not_configured": "No hub configured.",
       "lights": "Available lights"
     }
+  },
+  "scenes": {
+    "off": "Off"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -31,5 +31,8 @@
       "not_configured": "Aucun hub configuré.",
       "lights": "Lumières disponibles"
     }
+  },
+  "scenes": {
+    "off": "Éteint"
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,14 +30,16 @@ import Config, { GroupConfig, LightConfig, SceneConfig } from "./config.js";
 export const SCENE_NONE_OPTION = "—";
 
 /**
- * Option shown for turning a group off / reflecting that it is off.
+ * i18n key for the scene Select "Off" option.
  *
- * Unlike {@link SCENE_NONE_OPTION}, this option is always present in a group's scene
- * Select. It is the `current_option` whenever the group is off, and selecting it while the
- * group is on turns the entire group off. Like the placeholder, the caller (not
- * {@link buildSceneOptionsForGroup}) inserts it into the options list.
+ * Unlike {@link SCENE_NONE_OPTION} (a language-neutral em dash), the "Off" option is
+ * localized: it is always present in a group's scene Select, is the `current_option`
+ * whenever the group is off, and turns the entire group off when selected while on. The
+ * caller (not {@link buildSceneOptionsForGroup}) inserts the resolved label into the options
+ * list — use {@link localize} to render it in the active language and {@link isOffOption} to
+ * match an incoming/stored label against any supported language.
  */
-export const SCENE_OFF_OPTION = "Off";
+export const OFF_LABEL_KEY = "scenes.off";
 
 export function convertImageToBase64(file: string) {
   let data;
@@ -746,6 +748,33 @@ export function i18all(key: string): Record<string, string> {
     out.en = key;
   }
   return out;
+}
+
+/**
+ * Resolve a translation key to a single string in the given language.
+ *
+ * Single-language counterpart to {@link i18all}. Falls back to the configured default locale
+ * (English) and ultimately to the key itself if the phrase is missing.
+ *
+ * @param key translation key
+ * @param language target language code (e.g. "en", "de", "fr")
+ * @return the translated string for `language`
+ */
+export function localize(key: string, language: string): string {
+  return i18n.__({ phrase: key, locale: language });
+}
+
+/**
+ * Whether an option label is the "Off" scene-Select option in ANY supported language.
+ *
+ * Inbound select commands and previously-rendered labels are matched against every localized
+ * variant, so a language change between sending the options and receiving the command (or
+ * across a reconnect) still resolves correctly.
+ *
+ * @param option the option label to test
+ */
+export function isOffOption(option: string): boolean {
+  return Object.values(i18all(OFF_LABEL_KEY)).includes(option);
 }
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,12 +20,12 @@ import log from "./log.js";
 import Config, { GroupConfig, LightConfig, SceneConfig } from "./config.js";
 
 /**
- * Placeholder option shown when no scene is active in a group.
+ * Label of the "no scene active" placeholder option (a language-neutral em dash).
  *
  * The Select entity contract requires `current_option` to be one of the strings in
- * `options`, so we always include this marker at the top of every per-group scene
- * Select. Selecting it is a no-op (no bridge call) — it only ever appears as the
- * UI state when the bridge reports no scene active for the group.
+ * `options`. This marker is the `current_option` only while the group is on with no active
+ * scene; selecting it is a no-op. {@link buildSceneSelectOptions} reserves this label so a
+ * scene named "—" can't collide with it.
  */
 export const SCENE_NONE_OPTION = "—";
 
@@ -33,13 +33,22 @@ export const SCENE_NONE_OPTION = "—";
  * i18n key for the scene Select "Off" option.
  *
  * Unlike {@link SCENE_NONE_OPTION} (a language-neutral em dash), the "Off" option is
- * localized: it is always present in a group's scene Select, is the `current_option`
- * whenever the group is off, and turns the entire group off when selected while on. The
- * caller (not {@link buildSceneOptionsForGroup}) inserts the resolved label into the options
- * list — use {@link localize} to render it in the active language and {@link isOffOption} to
- * match an incoming/stored label against any supported language.
+ * localized via {@link localize}: it is always present in a group's scene Select, is the
+ * `current_option` whenever the group is off, and turns the entire group off when selected
+ * while on. {@link buildSceneSelectOptions} reserves the resolved label so a scene named like
+ * it can't collide.
  */
 export const OFF_LABEL_KEY = "scenes.off";
+
+/**
+ * One entry in a group's scene Select. The `kind` discriminates how a selected `label`
+ * dispatches; `label` is what the Remote displays and echoes back (the Select protocol has no
+ * separate id/value channel, so labels must be unique — see {@link buildSceneSelectOptions}).
+ */
+export type SceneSelectOption =
+  | { kind: "off"; label: string }
+  | { kind: "none"; label: string }
+  | { kind: "scene"; label: string; sceneId: string };
 
 export function convertImageToBase64(file: string) {
   let data;
@@ -112,41 +121,49 @@ export function addAvailableScenes(scenes: CombinedSceneResource[], config: Conf
 }
 
 /**
- * Build the option labels and lookup maps for a single group's scene Select entity.
+ * Build the ordered descriptor catalog for a single group's scene Select entity.
  *
- * The returned `options` array holds the group's scenes sorted alphabetically by name
- * (case-insensitive). Scenes with duplicate names get ` (2)`, ` (3)` suffixes — Hue allows
- * duplicate scene names within a group, but `current_option` is a string and must be unique
- * to disambiguate, so we deterministically suffix in iteration order.
+ * Returns `[off, none, ...scenes]` where scenes are sorted alphabetically by name
+ * (case-insensitive). Every descriptor's `label` is guaranteed unique: the two sentinel
+ * labels (`offLabel` and {@link SCENE_NONE_OPTION}) are reserved first, then scene names are
+ * assigned and any collision — a duplicate scene name, or a scene named like a sentinel — gets
+ * a ` (2)`, ` (3)`, … suffix. This is what lets a scene literally named "Off" or "—" stay
+ * selectable and recallable: it becomes "Off (2)" / "— (2)" and dispatches by its descriptor
+ * `kind`, not by string-matching a sentinel.
  *
- * This helper deliberately does **not** include {@link SCENE_NONE_OPTION}. The "no scene
- * active" placeholder is inserted by the caller only when it actually represents current
- * state — so it disappears from the dropdown whenever a real scene is active.
+ * The caller decides which descriptors appear in the emitted `options` array (the `none`
+ * placeholder only when it is the current option) and resolves an inbound option label back to
+ * its descriptor.
  *
- * Returns both directions of the option ↔ scene-id mapping so the SSE handlers (sceneId →
- * option) and the command handler (option → sceneId) can each do their lookup in O(1).
+ * @param scenes the group's scenes
+ * @param offLabel the localized "Off" label for the active language
  */
-export function buildSceneOptionsForGroup(scenes: (SceneConfig & { id: string })[]): {
-  options: string[];
-  optionToId: Map<string, string>;
-  idToOption: Map<string, string>;
-} {
-  const optionToId = new Map<string, string>();
-  const idToOption = new Map<string, string>();
-  const options: string[] = [];
+export function buildSceneSelectOptions(
+  scenes: (SceneConfig & { id: string })[],
+  offLabel: string
+): SceneSelectOption[] {
+  // Reserve the sentinel labels so a scene named like one gets suffixed instead of colliding.
+  const used = new Set<string>([offLabel, SCENE_NONE_OPTION]);
+  const uniqueLabel = (base: string): string => {
+    let label = base;
+    let n = 1;
+    while (used.has(label)) {
+      n += 1;
+      label = `${base} (${n})`;
+    }
+    used.add(label);
+    return label;
+  };
 
   const sorted = [...scenes].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
-  const seen = new Map<string, number>();
+  const options: SceneSelectOption[] = [
+    { kind: "off", label: offLabel },
+    { kind: "none", label: SCENE_NONE_OPTION }
+  ];
   for (const scene of sorted) {
-    const base = scene.name;
-    const count = (seen.get(base) ?? 0) + 1;
-    seen.set(base, count);
-    const label = count === 1 ? base : `${base} (${count})`;
-    options.push(label);
-    optionToId.set(label, scene.id);
-    idToOption.set(scene.id, label);
+    options.push({ kind: "scene", label: uniqueLabel(scene.name), sceneId: scene.id });
   }
-  return { options, optionToId, idToOption };
+  return options;
 }
 
 export function getLightFeatures(light: LightResource): LightFeatures[] {
@@ -762,19 +779,6 @@ export function i18all(key: string): Record<string, string> {
  */
 export function localize(key: string, language: string): string {
   return i18n.__({ phrase: key, locale: language });
-}
-
-/**
- * Whether an option label is the "Off" scene-Select option in ANY supported language.
- *
- * Inbound select commands and previously-rendered labels are matched against every localized
- * variant, so a language change between sending the options and receiving the command (or
- * across a reconnect) still resolves correctly.
- *
- * @param option the option label to test
- */
-export function isOffOption(option: string): boolean {
-  return Object.values(i18all(OFF_LABEL_KEY)).includes(option);
 }
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -29,6 +29,16 @@ import Config, { GroupConfig, LightConfig, SceneConfig } from "./config.js";
  */
 export const SCENE_NONE_OPTION = "—";
 
+/**
+ * Option shown for turning a group off / reflecting that it is off.
+ *
+ * Unlike {@link SCENE_NONE_OPTION}, this option is always present in a group's scene
+ * Select. It is the `current_option` whenever the group is off, and selecting it while the
+ * group is on turns the entire group off. Like the placeholder, the caller (not
+ * {@link buildSceneOptionsForGroup}) inserts it into the options list.
+ */
+export const SCENE_OFF_OPTION = "Off";
+
 export function convertImageToBase64(file: string) {
   let data;
 

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,7 +1,7 @@
 import test from "ava";
 import {
   brightnessToPercent,
-  buildSceneOptionsForGroup,
+  buildSceneSelectOptions,
   colorTempToMirek,
   convertHSVtoXY,
   convertXYtoHSV,
@@ -19,8 +19,6 @@ import {
   convertImageToBase64,
   i18all,
   isDeepEqual,
-  isOffOption,
-  OFF_LABEL_KEY,
   SCENE_NONE_OPTION
 } from "../src/util.js";
 import { SceneConfig } from "../src/config.js";
@@ -508,22 +506,6 @@ test("locale files define scenes.off for each supported language", (t) => {
   }
 });
 
-test("isOffOption matches the Off label in any supported language", (t) => {
-  const originalH = i18n.__h;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  i18n.__h = (key: string): any => (key === OFF_LABEL_KEY ? [{ en: "Off" }, { de: "Aus" }, { fr: "Éteint" }] : []);
-
-  try {
-    t.true(isOffOption("Off"));
-    t.true(isOffOption("Aus"));
-    t.true(isOffOption("Éteint"));
-    t.false(isOffOption("Relax"));
-    t.false(isOffOption(SCENE_NONE_OPTION));
-  } finally {
-    i18n.__h = originalH;
-  }
-});
-
 // --- isDeepEqual ---
 
 test("isDeepEqual compares primitives", (t) => {
@@ -587,42 +569,59 @@ function makeScene(id: string, name: string, groupId = "g1"): SceneConfig & { id
   return { id, name, groupId, groupRtype: "room", groupName: "Living Room" };
 }
 
-test("buildSceneOptionsForGroup returns an empty options array for an empty group", (t) => {
-  const result = buildSceneOptionsForGroup([]);
-  t.deepEqual(result.options, []);
-  t.is(result.optionToId.size, 0);
-  t.is(result.idToOption.size, 0);
+// Helper: scene labels (kind === "scene") in catalog order.
+function sceneLabels(options: ReturnType<typeof buildSceneSelectOptions>): string[] {
+  return options.filter((o) => o.kind === "scene").map((o) => o.label);
+}
+
+test("buildSceneSelectOptions always leads with the off and none sentinels", (t) => {
+  const result = buildSceneSelectOptions([], "Off");
+  t.deepEqual(
+    result.map((o) => o.kind),
+    ["off", "none"]
+  );
+  t.is(result[0].label, "Off");
+  t.is(result[1].label, SCENE_NONE_OPTION);
 });
 
-test("buildSceneOptionsForGroup sorts scenes alphabetically without prepending a placeholder", (t) => {
-  const scenes = [makeScene("s1", "Bright"), makeScene("s2", "Cozy"), makeScene("s3", "Ambient")];
-  const result = buildSceneOptionsForGroup(scenes);
-  t.deepEqual(result.options, ["Ambient", "Bright", "Cozy"]);
-  t.false(result.options.includes(SCENE_NONE_OPTION), "placeholder is not embedded in helper output");
-  t.is(result.optionToId.get("Ambient"), "s3");
-  t.is(result.optionToId.get("Bright"), "s1");
-  t.is(result.optionToId.get("Cozy"), "s2");
-});
-
-test("buildSceneOptionsForGroup sorts case-insensitively", (t) => {
+test("buildSceneSelectOptions sorts scenes alphabetically (case-insensitive) after the sentinels", (t) => {
   const scenes = [makeScene("s1", "bright"), makeScene("s2", "Ambient"), makeScene("s3", "Cozy")];
-  const result = buildSceneOptionsForGroup(scenes);
-  t.deepEqual(result.options, ["Ambient", "bright", "Cozy"]);
+  const result = buildSceneSelectOptions(scenes, "Off");
+  t.deepEqual(sceneLabels(result), ["Ambient", "bright", "Cozy"]);
+  const ambient = result.find((o) => o.kind === "scene" && o.label === "Ambient");
+  t.is(ambient?.kind === "scene" ? ambient.sceneId : undefined, "s2");
 });
 
-test("buildSceneOptionsForGroup suffixes duplicate scene names with (2), (3)", (t) => {
+test("buildSceneSelectOptions suffixes duplicate scene names with (2), (3)", (t) => {
   const scenes = [makeScene("s1", "Movie Night"), makeScene("s2", "Movie Night"), makeScene("s3", "Movie Night")];
-  const result = buildSceneOptionsForGroup(scenes);
-  t.deepEqual(result.options, ["Movie Night", "Movie Night (2)", "Movie Night (3)"]);
-  t.is(result.optionToId.get("Movie Night"), "s1");
-  t.is(result.optionToId.get("Movie Night (2)"), "s2");
-  t.is(result.optionToId.get("Movie Night (3)"), "s3");
+  const result = buildSceneSelectOptions(scenes, "Off");
+  t.deepEqual(sceneLabels(result), ["Movie Night", "Movie Night (2)", "Movie Night (3)"]);
 });
 
-test("buildSceneOptionsForGroup builds matching forward and reverse maps", (t) => {
-  const scenes = [makeScene("s1", "Bright"), makeScene("s2", "Bright")];
-  const result = buildSceneOptionsForGroup(scenes);
-  for (const [option, sceneId] of result.optionToId) {
-    t.is(result.idToOption.get(sceneId), option);
-  }
+test("buildSceneSelectOptions suffixes a scene that collides with the off label", (t) => {
+  const result = buildSceneSelectOptions([makeScene("s1", "Off")], "Off");
+  // The off sentinel keeps the bare "Off"; the scene named "Off" is suffixed and stays a scene.
+  t.is(result.find((o) => o.kind === "off")?.label, "Off");
+  const scene = result.find((o) => o.kind === "scene");
+  t.is(scene?.label, "Off (2)");
+  t.is(scene?.kind === "scene" ? scene.sceneId : undefined, "s1");
+});
+
+test("buildSceneSelectOptions suffixes a scene that collides with the localized off label", (t) => {
+  const result = buildSceneSelectOptions([makeScene("s1", "Aus")], "Aus");
+  t.is(result.find((o) => o.kind === "off")?.label, "Aus");
+  t.is(result.find((o) => o.kind === "scene")?.label, "Aus (2)");
+});
+
+test("buildSceneSelectOptions suffixes a scene that collides with the — placeholder", (t) => {
+  const result = buildSceneSelectOptions([makeScene("s1", SCENE_NONE_OPTION)], "Off");
+  t.is(result.find((o) => o.kind === "none")?.label, SCENE_NONE_OPTION);
+  t.is(result.find((o) => o.kind === "scene")?.label, `${SCENE_NONE_OPTION} (2)`);
+});
+
+test("buildSceneSelectOptions produces unique labels across all descriptors", (t) => {
+  const scenes = [makeScene("s1", "Off"), makeScene("s2", "Off"), makeScene("s3", SCENE_NONE_OPTION)];
+  const result = buildSceneSelectOptions(scenes, "Off");
+  const labels = result.map((o) => o.label);
+  t.is(new Set(labels).size, labels.length, "no duplicate labels");
 });

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -19,6 +19,8 @@ import {
   convertImageToBase64,
   i18all,
   isDeepEqual,
+  isOffOption,
+  OFF_LABEL_KEY,
   SCENE_NONE_OPTION
 } from "../src/util.js";
 import { SceneConfig } from "../src/config.js";
@@ -491,6 +493,32 @@ test("i18all returns translations", (t) => {
 
     const emptyResult = i18all("unknown");
     t.is(emptyResult.en, "unknown");
+  } finally {
+    i18n.__h = originalH;
+  }
+});
+
+// --- scene Select "Off" localization ---
+
+test("locale files define scenes.off for each supported language", (t) => {
+  const expected: Record<string, string> = { en: "Off", de: "Aus", fr: "Éteint" };
+  for (const [lang, value] of Object.entries(expected)) {
+    const json = JSON.parse(fs.readFileSync(`src/locales/${lang}.json`, "utf-8"));
+    t.is(json.scenes?.off, value, `${lang}.json scenes.off`);
+  }
+});
+
+test("isOffOption matches the Off label in any supported language", (t) => {
+  const originalH = i18n.__h;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  i18n.__h = (key: string): any => (key === OFF_LABEL_KEY ? [{ en: "Off" }, { de: "Aus" }, { fr: "Éteint" }] : []);
+
+  try {
+    t.true(isOffOption("Off"));
+    t.true(isOffOption("Aus"));
+    t.true(isOffOption("Éteint"));
+    t.false(isOffOption("Relax"));
+    t.false(isOffOption(SCENE_NONE_OPTION));
   } finally {
     i18n.__h = originalH;
   }


### PR DESCRIPTION
# Description

Builds on the per-group scene `Select` added in #134 (v0.4.0), where the `Off` option was first proposed. Adds an `Off` option to each group's scene Select:

- It is the selected option whenever the group is off.
- When the group is on, selecting it turns the entire group off.

Supporting changes:

- Scene Select options are modeled as a typed descriptor catalog (`off` / `none` / `scene`) with guaranteed-unique labels, so a scene named like a sentinel (`Off`, `Aus`, `—`, …) is suffixed (e.g. `Off (2)`) and stays selectable/recallable instead of being shadowed. This also fixes a pre-existing collision for a scene literally named `—`.
- The `Off` label is resolved through i18n so it can be localized (de/fr included). The active-language source is isolated behind a single `resolveLanguage()` and returns English for now — the Node integration SDK has no API to query the remote's language yet (only the Python `ucapi` lib's `get_localization_cfg`); when that lands it's a one-line swap.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

(Also fixes the latent collision where a scene named `—` was shadowed.)

# How Has This Been Tested?

- `npm run code-check` and `npm run test` — 72 unit tests pass, including the new descriptor-catalog collision cases.
- Validated on hardware (Hue Bridge Pro + real bulbs on a Remote) throughout development:
  - group off → Select shows `Off`; on with no scene → `—`; scene active → scene name
  - selecting `Off` while on turns the whole group off
  - turning the group on from its Light entity moves `Off` → `—`
  - a scene named `Off` shows as `Off (2)` and still recalls

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request represents one logical piece of work. Do not combine multiple unrelated changes into a single pull request.
- [x] My changes pass the linter checks `npm run code-check` and unit tests `npm run test`. PRs with failing linter or unit tests will not be merged.
- [x] I have tested and performed a self-review of my code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
