### PR TITLE
fix: auto-shorten hostname for Philips Hue deviceType parameter

### DIFF
--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -35,6 +35,56 @@ import * as uc from "@unfoldedcircle/integration-api";
 import net from "net";
 
 /**
+ * Maximum length for the device name portion of the deviceType.
+ * Philips Hue API v2 limits deviceName to 19 characters.
+ */
+const MAX_DEVICE_NAME_LENGTH = 19;
+
+/**
+ * Creates a device type name for Philips Hue authentication.
+ *
+ * The Philips Hue API v2 has strict limits on the deviceType parameter:
+ * - applicationName: max 20 characters
+ * - deviceName: max 19 characters
+ * - Combined format: <application_name>#<device_name>
+ *
+ * This function automatically shortens the deviceName to fit within the limit.
+ * Shortening strategy (in order):
+ * 1. Remove domain suffixes from right to left (e.g., ".local", ".subdomain.local")
+ *    to preserve the hostname which is the most important information.
+ * 2. Replace "RemoteTwo" with "R2" and "RemoteThree" with "R3"
+ * 3. Truncate to maximum length if still too long
+ *
+ * @param applicationName - The application name (e.g., "unfoldedcircle")
+ * @param deviceName - The device name (e.g., hostname) to be shortened if needed
+ * @returns A device type string in the format "applicationName#deviceName"
+ */
+export function createDeviceTypeName(applicationName: string, deviceName: string): string {
+  let shortenedName = deviceName;
+
+  // Step 1: Remove domain suffixes from right to left (e.g., ".local", ".subdomain.local")
+  // This preserves the hostname which is the most important information
+  while (shortenedName.length > MAX_DEVICE_NAME_LENGTH && shortenedName.includes(".")) {
+    // Remove the last domain segment (everything from the last dot onwards)
+    const lastDotIndex = shortenedName.lastIndexOf(".");
+    shortenedName = shortenedName.substring(0, lastDotIndex);
+  }
+
+  // Step 2: Replace "RemoteTwo" with "R2" and "Remote3" with "R3" if still too long
+  if (shortenedName.length > MAX_DEVICE_NAME_LENGTH) {
+    shortenedName = shortenedName.replace(/RemoteTwo/g, "R2");
+    shortenedName = shortenedName.replace(/Remote3/g, "R3");
+  }
+
+  // Step 3: Finally, truncate to maximum length if still too long
+  if (shortenedName.length > MAX_DEVICE_NAME_LENGTH) {
+    shortenedName = shortenedName.substring(0, MAX_DEVICE_NAME_LENGTH);
+  }
+
+  return `${applicationName}#${shortenedName}`;
+}
+
+/**
  * Enumeration of setup steps to keep track of user data responses.
  */
 enum SetupSteps {
@@ -294,7 +344,8 @@ class PhilipsHueSetup {
     if (msg.confirm && this.selectedHub) {
       try {
         const api = this.hueApiFactory(getHubUrl(this.selectedHub.ip));
-        const authKey = await api.generateAuthKey("unfoldedcircle#" + os.hostname());
+        const deviceType = createDeviceTypeName("unfoldedcircle", os.hostname());
+        const authKey = await api.generateAuthKey(deviceType);
         api.setAuthKey(authKey.username);
         this.config.updateHubConfig({
           name: this.selectedHub.name,

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -1,5 +1,5 @@
 import test from "ava";
-import PhilipsHueSetup from "../src/lib/setup.js";
+import PhilipsHueSetup, { createDeviceTypeName } from "../src/lib/setup.js";
 import Config from "../src/config.js";
 import * as uc from "@unfoldedcircle/integration-api";
 import { Bonjour, Service } from "bonjour-service";
@@ -87,4 +87,113 @@ test("handleHubDiscovery should normalize bridge ID for manual setup", async (t)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const field = inputRequest.settings[0].field as any;
   t.is(field.dropdown.items[0].id, "001122334455"); // should be normalized
+});
+
+// Tests for createDeviceTypeName function
+test("createDeviceTypeName - short hostname without domain", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "myhost");
+  t.is(result, "unfoldedcircle#myhost");
+  t.true(result.length <= 33); // 14 + 1 + 18 max
+});
+
+test("createDeviceTypeName - hostname with .local suffix", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "myhost.local");
+  // "myhost.local" is 12 chars, fits without shortening
+  t.is(result, "unfoldedcircle#myhost.local");
+});
+
+test("createDeviceTypeName - hostname with multiple domain segments", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "host.subdomain.local");
+  // "host.subdomain.local" is 20 chars, > 19
+  // Remove from right: "host.subdomain.local" -> "host.subdomain" (14 chars, fits)
+  t.is(result, "unfoldedcircle#host.subdomain");
+});
+
+test("createDeviceTypeName - hostname still too long after removing domain", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "verylonghostname.subdomain.local");
+  // Remove from right to left:
+  // "verylonghostname.subdomain.local" -> "verylonghostname.subdomain" (27 chars, still > 19)
+  // "verylonghostname.subdomain" -> "verylonghostname" (18 chars, fits)
+  t.is(result, "unfoldedcircle#verylonghostname");
+});
+
+test("createDeviceTypeName - hostname with RemoteTwo replacement", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "RemoteTwo.local");
+  // "RemoteTwo.local" is 15 chars, fits without shortening
+  t.is(result, "unfoldedcircle#RemoteTwo.local");
+});
+
+test("createDeviceTypeName - RemoteTwo in longer hostname", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "RemoteTwoABCDEF123456");
+  // "RemoteTwoABCDEF123456" is 20 chars, > 19
+  // Replace RemoteTwo with R2: "R2ABCDEF123456" = 14 chars, fits
+  t.is(result, "unfoldedcircle#R2ABCDEF123456");
+});
+
+test("createDeviceTypeName - Remote3 in longer hostname", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "Remote3ABCDEF1234567890123456789");
+  t.is(result, "unfoldedcircle#R3ABCDEF12345678901");
+});
+
+test("createDeviceTypeName - RemoteTwo with domain too long", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "RemoteTwoABCDEF123456.local");
+  // "RemoteTwoABCDEF123456.local" is 26 chars, > 19
+  // Remove ".local" -> "RemoteTwoABCDEF123456" (20 chars, still > 19)
+  // Replace RemoteTwo with R2: "R2ABCDEF123456" = 14 chars, fits
+  t.is(result, "unfoldedcircle#R2ABCDEF123456");
+});
+
+test("createDeviceTypeName - RemoteTwo replacement still too long", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "RemoteTwoABCDEF1234567890");
+  // "RemoteTwoABCDEF1234567890" is 24 chars
+  // Replace RemoteTwo with R2: "R2ABCDEF1234567890" = 18 chars, fits
+  t.is(result, "unfoldedcircle#R2ABCDEF1234567890");
+});
+
+test("createDeviceTypeName - Remote3 replacement", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "Remote3.local");
+  // "Remote3.local" is 13 chars, fits without shortening
+  t.is(result, "unfoldedcircle#Remote3.local");
+});
+
+test("createDeviceTypeName - truncation when still too long", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "ABCDEFGHIJKLMNOPQRST");
+  // 20 chars, no domain, no RemoteTwo to replace -> truncate to 19
+  t.is(result, "unfoldedcircle#ABCDEFGHIJKLMNOPQRS");
+  t.is(result.length, 34); // 14 + 1 + 19
+});
+
+test("createDeviceTypeName - exactly 19 characters", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "ABCDEFGHIJKLMNOPQRS");
+  // Exactly 19 chars, should not be truncated
+  t.is(result, "unfoldedcircle#ABCDEFGHIJKLMNOPQRS");
+  t.is(result.length, 34); // 14 + 1 + 19
+});
+
+test("createDeviceTypeName - empty device name", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "");
+  t.is(result, "unfoldedcircle#");
+});
+
+test("createDeviceTypeName - only domain suffix", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", ".local");
+  // ".local" is 6 chars, fits without shortening
+  t.is(result, "unfoldedcircle#.local");
+});
+
+test("createDeviceTypeName - complex real-world hostname", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "MyRemoteTwoHome.local");
+  // "MyRemoteTwoHome.local" is 21 chars, > 19
+  // Remove ".local" -> "MyRemoteTwoHome" (15 chars, fits)
+  t.is(result, "unfoldedcircle#MyRemoteTwoHome");
+});
+
+test("createDeviceTypeName - very long hostname with multiple dots", (t) => {
+  const result = createDeviceTypeName("unfoldedcircle", "verylonghostname.subdomain.example.local");
+  // Remove from right to left:
+  // "verylonghostname.subdomain.example.local" (41 chars)
+  // -> "verylonghostname.subdomain.example" (36 chars)
+  // -> "verylonghostname.subdomain" (26 chars)
+  // -> "verylonghostname" (18 chars, fits)
+  t.is(result, "unfoldedcircle#verylonghostname");
 });


### PR DESCRIPTION
# Description

The Philips Hue API v2 limits the `deviceType` parameter to 40 characters total, with the `deviceName` portion limited to 19 characters.
The unique hostname is used as `deviceName` parameter.
Long hostnames (e.g., `RemoteTwo-######.local` with domain suffix) would cause authentication to fail.

Add createDeviceTypeName function to automatically shorten hostnames:
- Remove domain suffixes from right to left, preserving the hostname
- Replace "RemoteTwo" with "R2" and "Remote3" with "R3"
- Truncate to 19 characters maximum as final fallback

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Added unit tests verifying maximum deviceType parameter lenght
- Manual API calls to Philips Hue bridge
- Manual integration setup using a RemoteTwo hostname with domain suffix

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request represents one logical piece of work. Do not combine multiple unrelated changes into a single pull request.
- [x] My changes pass the linter checks `npm run code-check` and unit tests `npm run test`. PRs with failing linter or unit tests will not be merged.
- [x] I have tested and performed a self-review of my code

---

- Fixes #149
- Relates to https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/787

