### PR TITLE
fix: Ensure that selects are marked as on

### DIFF
--- a/src/lib/philips-hue.ts
+++ b/src/lib/philips-hue.ts
@@ -577,6 +577,7 @@ class PhilipsHue {
     if (available.contains(entityId)) {
       const configured = this.uc.getConfiguredEntities();
       const updates: Record<string, string | string[] | SelectStates> = {
+        [SelectAttributes.State]: SelectStates.On,
         [SelectAttributes.Options]: options,
         [SelectAttributes.CurrentOption]: currentOption
       };
@@ -665,6 +666,7 @@ class PhilipsHue {
       ? (this.findSceneOption(groupId, sceneId)?.label ?? this.noSceneLabel(groupId))
       : this.noSceneLabel(groupId);
     const updates = {
+      [SelectAttributes.State]: SelectStates.On,
       [SelectAttributes.CurrentOption]: option,
       [SelectAttributes.Options]: this.optionsForCurrent(groupId, option)
     };


### PR DESCRIPTION
# Description
Attempts to fix an issue where state on select entities are stuck on `Unknown`

Fixes #170

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Running it locally and setting it up on my remote. Added a select entity to the Home Screen and toggled its status. Also tried recovery when the remote goes out of sleep as well as when the Philips Hue hub is disconnected from the network and comes back online.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request represents one logical piece of work. Do not combine multiple unrelated changes into a single pull request.
- [x] My changes pass the linter checks `npm run code-check` and unit tests `npm run test`. PRs with failing linter or unit tests will not be merged.
- [x] I have tested and performed a self-review of my code

